### PR TITLE
Package List: booleanGlyph → booleanOperations

### DIFF
--- a/COMPILE.md
+++ b/COMPILE.md
@@ -13,7 +13,7 @@ drawBot.app
 * [fontTools](https://github.com/behdad/fonttools)
 * [pygments](http://pygments.org)
 * [jedi](http://jedi.jedidjah.ch/en/latest/)
-* [booleanGlyph](https://github.com/typemytype/booleanOperations)
+* [booleanOperations](https://github.com/typemytype/booleanOperations)
 * [mutatorMath](https://github.com/LettError/MutatorMath)
 * [woffTools](https://github.com/typesupply/woffTools)
 * [compositor](https://github.com/typesupply/compositor)


### PR DESCRIPTION
This change makes it clearer, perhaps.

I stumbled upon the discrepancy between name and package when I was manually testing the import for all modules.
Since `booleanGlyph` cannot be directly imported, the import threw an error. But since it is part of the `booleanOperations` package, all is good.

(I don’t know why the last line wants to be changed, this is thanks to Github. Feel free to dismiss this PR and do the change manually).