### PR TITLE
More accurate movie timing by using a ratio for the frameDuration

### DIFF
--- a/drawBot/context/gifContext.py
+++ b/drawBot/context/gifContext.py
@@ -28,6 +28,9 @@ class GifContext(ImageContext):
         self._delayData = []
 
     def _frameDuration(self, seconds):
+        if type(seconds) is tuple:
+            # Duration as a ratio, turn it into a fraction of a second
+            seconds = seconds[0] / seconds[1]
         # gifsicle -h: Set frame delay to TIME (in 1/100sec).
         self._delayData[-1] = int(seconds * 100)
 

--- a/drawBot/context/movContext.py
+++ b/drawBot/context/movContext.py
@@ -32,8 +32,13 @@ class MOVContext(PDFContext):
         self.restore()
 
     def _frameDuration(self, seconds):
-        length = seconds * self._frameScale
-        self._frameDurationData[-1] = length, self._frameScale
+        if type(seconds) is tuple:
+            # Duration as a ratio
+            self._frameDurationData[-1] = seconds
+        else:
+            # Duration as a fraction of a second, turn it into a ratio of _frameScale
+            length = seconds * self._frameScale
+            self._frameDurationData[-1] = length, self._frameScale
 
     def _writeDataToFile(self, data, path, multipage):
         if os.path.exists(path):


### PR DESCRIPTION
More accurate frame timing is possible when using a ratio for the frameDuration, rather than a floating point, since the QTMovie ends up needing a ratio for the frame duration. I made it so that the old API works too, the frameDuration can either be given as a float or as a tuple.

fps = 60
frameDuration(1 / fps) # as a float
frameDuration((1, fps)) # as a ratio

I found that the rounding error when converting from a float back into a ratio can result in timing problems in the movie when trying to sync the movie to events in an audio track.

The attached Python script will aim to make two 30-second long 60fps movies. Open them up in QuickTime Player and check the Inspector window: the movie made with a floating point frameDuration ends up as 27-seconds long and 66.67fps, but the movie with the frameDuration as a ratio ends up with the correct length and rate.

Thanks!!
Andy

[frameDurationTest.py.zip](https://github.com/typemytype/drawbot/files/271863/frameDurationTest.py.zip)


