### PR TITLE
Added the ability to create links within a PDF

### DIFF
--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -1361,6 +1361,13 @@ class BaseContext(object):
 
     def _printImage(self, pdf=None):
         pass
+    
+    def _linkDestination(self, name, (x, y)):
+        pass
+
+    def _linkRect(self, name, (x, y, w, h)):
+        pass
+    
 
     ###
 
@@ -1763,3 +1770,9 @@ class BaseContext(object):
         if psName is not None:
             psName = psName.toUnicode()
         return psName
+
+    def linkDestination(self, name, (x, y)):
+        self._linkDestination(name, (x, y))
+    
+    def linkRect(self, name, (x, y, w, h)):
+        self._linkRect(name, (x, y, w, h))

--- a/drawBot/context/pdfContext.py
+++ b/drawBot/context/pdfContext.py
@@ -350,3 +350,15 @@ class PDFContext(BaseContext):
             # gray color
             return Quartz.CGColorCreateGenericGray(c.whiteComponent(), c.alphaComponent())
         return Quartz.CGColorCreateGenericRGB(c.redComponent(), c.greenComponent(), c.blueComponent(), c.alphaComponent())
+    
+    def _linkDestination(self, name, (x, y)):
+        if (x, y) == (None, None):
+            x, y = self.width * 0.5, self.height * 0.5
+        x = max(0, min(x, self.width))
+        y = max(0, min(y, self.height))
+        centerPoint = Quartz.CGPoint(x, y)
+        Quartz.CGPDFContextAddDestinationAtPoint(self._pdfContext, name, centerPoint)
+
+    def _linkRect(self, name, (x, y, w, h)):
+        rectBox = Quartz.CGRectMake(x, y, w, h)
+        Quartz.CGPDFContextSetDestinationForRect(self._pdfContext, name, rectBox)

--- a/drawBot/drawBotDrawingTools.py
+++ b/drawBot/drawBotDrawingTools.py
@@ -1152,6 +1152,28 @@ class DrawBotDrawingTool(object):
     def frameduration(self, seconds):
         _deprecatedWarningLowercase("frameDuration(%s)" % seconds)
         self.frameDuration(seconds)
+        
+        
+    # pdf links
+    
+    def linkDestination(self, name, x=None, y=None):
+        """
+        Add a destination point for a link within a PDF.
+        """
+        if x:
+            if len(x) == 2:
+                x, y = x
+            else: x, y = (None, None)
+        self._requiresNewFirstPage = True
+        self._addInstruction("linkDestination", name, (x, y))
+    
+    def linkRect(self, name, (x, y, w, h)):
+        """
+        Add a rect for a link within a PDF.
+        """
+        self._requiresNewFirstPage = True
+        self._addInstruction("linkRect", name, (x, y, w, h))
+        
 
     # helpers
 


### PR DESCRIPTION
Add a link rect with the name of a link on one page, and a link destination location with the same name on another page. The (x,y) location of the link destination defaults to None, in which case the link destination will be placed in the center of the page.