### PR TITLE
Add alignment to text().

### DIFF
--- a/drawBot/drawBotDrawingTools.py
+++ b/drawBot/drawBotDrawingTools.py
@@ -1011,7 +1011,7 @@ class DrawBotDrawingTool(object):
 
     # drawing text
 
-    def text(self, txt, x, y=None):
+    def text(self, txt, x, y=None, align=None):
         """
         Draw a text at a provided position.
 
@@ -1037,7 +1037,7 @@ class DrawBotDrawingTool(object):
         if origins:
             x -= origins[-1][0]
             y -= origins[-1][1]
-        self.textBox(txt, (x, y-h, w*2, h*2))
+        self.textBox(txt, (x, y-h, w*2, h*2), align=align)
 
     def textOverflow(self, txt, box, align=None):
         """


### PR DESCRIPTION
Previously, text() would use whatever alignments have been used for
textBox() without being able to explicitly revert/set the alignment for
text(). Only an empty textBox() with an alignment would set the alignment
for text().