### PR TITLE
Various py3 changes; should all still work on py2.7, too

### DIFF
--- a/DrawBot.py
+++ b/DrawBot.py
@@ -25,7 +25,7 @@ class DrawBotDocument(AppKit.NSDocument):
     def writeSafelyToURL_ofType_forSaveOperation_error_(self, url, fileType, saveOperation, error):
         path = url.path()
         code = self.vanillaWindowController.code()
-        f = file(path, "w")
+        f = open(path, "wb")
         f.write(code.encode("utf8"))
         f.close()
         self._modDate = self.getModificationDate(path)

--- a/DrawBot.py
+++ b/DrawBot.py
@@ -102,7 +102,7 @@ class DrawBotAppDelegate(AppKit.NSObject):
 
     def init(self):
         self = super(DrawBotAppDelegate, self).init()
-        code = stringToInt("GURL")
+        code = stringToInt(b"GURL")
         AppKit.NSAppleEventManager.sharedAppleEventManager().setEventHandler_andSelector_forEventClass_andEventID_(self, "getUrl:withReplyEvent:", code, code)
         return self
 
@@ -146,7 +146,7 @@ class DrawBotAppDelegate(AppKit.NSObject):
     def getUrl_withReplyEvent_(self, event, reply):
         import urlparse
         import urllib2
-        code = stringToInt("----")
+        code = stringToInt(b"----")
         url = event.paramDescriptorForKeyword_(code)
         urlString = url.stringValue()
         documentController = AppKit.NSDocumentController.sharedDocumentController()

--- a/drawBot/__init__.py
+++ b/drawBot/__init__.py
@@ -1,3 +1,5 @@
-from drawBotDrawingTools import _drawBotDrawingTool
+from __future__ import absolute_import
+
+from .drawBotDrawingTools import _drawBotDrawingTool
 
 _drawBotDrawingTool._addToNamespace(globals())

--- a/drawBot/context/__init__.py
+++ b/drawBot/context/__init__.py
@@ -1,9 +1,11 @@
-from pdfContext import PDFContext
-from imageContext import ImageContext
-from gifContext import GifContext
-from svgContext import SVGContext
-from movContext import MOVContext
-from printContext import PrintContext
+from __future__ import absolute_import
+
+from .pdfContext import PDFContext
+from .imageContext import ImageContext
+from .gifContext import GifContext
+from .svgContext import SVGContext
+from .movContext import MOVContext
+from .printContext import PrintContext
 
 
 allContexts = [PDFContext, ImageContext, SVGContext, MOVContext, PrintContext, GifContext]

--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -7,6 +7,7 @@ import Quartz
 import math
 
 from fontTools.pens.basePen import BasePen
+from fontTools.misc.py23 import basestring, PY2
 
 from drawBot.misc import DrawBotError, cmyk2rgb, warnings
 
@@ -906,7 +907,7 @@ class FormattedString(object):
 
         Text can also be added with `formattedString += "hello"`. It will append the text with the current settings of the formatted string.
         """
-        if isinstance(txt, (str, unicode)):
+        if PY2 and isinstance(txt, basestring):
             try:
                 txt = txt.decode("utf-8")
             except UnicodeEncodeError:
@@ -1042,7 +1043,7 @@ class FormattedString(object):
         if isinstance(txt, self.__class__):
             new.getNSObject().appendAttributedString_(txt.getNSObject())
         else:
-            if not isinstance(txt, (str, unicode)):
+            if not isinstance(txt, basestring):
                 raise TypeError("FormattedString requires a str or unicode, got '%s'" % type(txt))
             new.append(txt)
         return new
@@ -1110,7 +1111,7 @@ class FormattedString(object):
         from a path.
         """
         font = _tryInstallFontFromFontName(font)
-        font = font.encode("ascii", "ignore")
+        font = font.encode("ascii", "ignore").decode("ascii")
         self._font = font
         if fontSize is not None:
             self._fontSize = fontSize
@@ -1123,7 +1124,7 @@ class FormattedString(object):
         """
         if font:
             font = _tryInstallFontFromFontName(font)
-            font = font.encode("ascii", "ignore")
+            font = font.encode("ascii", "ignore").decode("ascii")
             testFont = AppKit.NSFont.fontWithName_size_(font, self._fontSize)
             if testFont is None:
                 raise DrawBotError("Fallback font '%s' is not available" % font)

--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -7,7 +7,7 @@ import Quartz
 import math
 
 from fontTools.pens.basePen import BasePen
-from fontTools.misc.py23 import basestring, PY2
+from fontTools.misc.py23 import basestring, PY2, unichr
 
 from drawBot.misc import DrawBotError, cmyk2rgb, warnings
 

--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -1111,7 +1111,7 @@ class FormattedString(object):
         from a path.
         """
         font = _tryInstallFontFromFontName(font)
-        font = font.encode("ascii", "ignore").decode("ascii")
+        font = str(font)
         self._font = font
         if fontSize is not None:
             self._fontSize = fontSize
@@ -1124,7 +1124,7 @@ class FormattedString(object):
         """
         if font:
             font = _tryInstallFontFromFontName(font)
-            font = font.encode("ascii", "ignore").decode("ascii")
+            font = str(font)
             testFont = AppKit.NSFont.fontWithName_size_(font, self._fontSize)
             if testFont is None:
                 raise DrawBotError("Fallback font '%s' is not available" % font)

--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import AppKit
 import CoreText
 import Quartz
@@ -8,8 +10,8 @@ from fontTools.pens.basePen import BasePen
 
 from drawBot.misc import DrawBotError, cmyk2rgb, warnings
 
-from tools import openType
-from tools import variation
+from .tools import openType
+from .tools import variation
 
 
 _FALLBACKFONT = "LucidaGrande"
@@ -333,10 +335,11 @@ class BezierPath(BasePen):
         """
         self._path = path
 
-    def pointInside(self, (x, y)):
+    def pointInside(self, xy):
         """
         Check if a point `x`, `y` is inside a path.
         """
+        x, y = xy
         return self._path.containsPoint_((x, y))
 
     def bounds(self):
@@ -930,7 +933,7 @@ class FormattedString(object):
                 existingOpenTypeFeatures = openType.getFeatureTagsForFontName(self._font)
                 # sort features by their on/off state
                 # set all disabled features first
-                orderedOpenTypeFeatures = sorted(self._openTypeFeatures.items(), key=lambda (k, v): v)
+                orderedOpenTypeFeatures = sorted(self._openTypeFeatures.items(), key=lambda kv: kv[1])
                 for featureTag, value in orderedOpenTypeFeatures:
                     coreTextFeatureTag = featureTag
                     if not value:
@@ -1755,7 +1758,7 @@ class BaseContext(object):
     def _textBox(self, txt, box, align):
         pass
 
-    def _image(self, path, (x, y), alpha, pageNumber):
+    def _image(self, path, xy, alpha, pageNumber):
         pass
 
     def _frameDuration(self, seconds):
@@ -1770,10 +1773,10 @@ class BaseContext(object):
     def _printImage(self, pdf=None):
         pass
 
-    def _linkDestination(self, name, (x, y)):
+    def _linkDestination(self, name, xy):
         pass
 
-    def _linkRect(self, name, (x, y, w, h)):
+    def _linkRect(self, name, xywh):
         pass
 
     #
@@ -2185,7 +2188,8 @@ class BaseContext(object):
         self._state.path = None
         self._textBox(txt, box, align)
 
-    def image(self, path, (x, y), alpha, pageNumber):
+    def image(self, path, xy, alpha, pageNumber):
+        x, y = xy
         self._image(path, (x, y), alpha, pageNumber)
 
     def installFont(self, path):
@@ -2218,8 +2222,10 @@ class BaseContext(object):
             psName = psName.toUnicode()
         return psName
 
-    def linkDestination(self, name, (x, y)):
+    def linkDestination(self, name, xy):
+        x, y = xy
         self._linkDestination(name, (x, y))
 
-    def linkRect(self, name, (x, y, w, h)):
+    def linkRect(self, name, xywh):
+        x, y, w, h = xywh
         self._linkRect(name, (x, y, w, h))

--- a/drawBot/context/drawBotContext.py
+++ b/drawBot/context/drawBotContext.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
+
 import Quartz
 
-from pdfContext import PDFContext
+from .pdfContext import PDFContext
 
 
 class DrawBotContext(PDFContext):

--- a/drawBot/context/dummyContext.py
+++ b/drawBot/context/dummyContext.py
@@ -1,4 +1,6 @@
-from baseContext import BaseContext
+from __future__ import absolute_import, print_function
+
+from .baseContext import BaseContext
 
 
 class DummyContext(BaseContext):

--- a/drawBot/context/gifContext.py
+++ b/drawBot/context/gifContext.py
@@ -1,11 +1,13 @@
+from __future__ import absolute_import
+
 import AppKit
 import Quartz
 
 import tempfile
 
-from imageContext import ImageContext
+from .imageContext import ImageContext
 
-from tools.gifTools import generateGif
+from .tools.gifTools import generateGif
 
 
 class GifContext(ImageContext):

--- a/drawBot/context/imageContext.py
+++ b/drawBot/context/imageContext.py
@@ -1,9 +1,11 @@
+from __future__ import absolute_import
+
 import AppKit
 import Quartz
 
 import os
 
-from pdfContext import PDFContext
+from .pdfContext import PDFContext
 
 
 class ImageContext(PDFContext):

--- a/drawBot/context/movContext.py
+++ b/drawBot/context/movContext.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import AppKit
 import QTKit
 import Quartz
@@ -5,7 +7,7 @@ import Quartz
 import os
 
 from drawBot.misc import DrawBotError
-from pdfContext import PDFContext
+from .pdfContext import PDFContext
 
 
 class MOVContext(PDFContext):

--- a/drawBot/context/pdfContext.py
+++ b/drawBot/context/pdfContext.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import platform
 from distutils.version import StrictVersion
 import AppKit
@@ -6,9 +8,9 @@ import Quartz
 
 import math
 
-from tools import gifTools
+from .tools import gifTools
 
-from baseContext import BaseContext, FormattedString
+from .baseContext import BaseContext, FormattedString
 from drawBot.misc import DrawBotError, isPDF, isGIF
 
 
@@ -263,7 +265,8 @@ class PDFContext(BaseContext):
                     raise DrawBotError("No image found at %s" % key)
         return self._cachedImages[key]
 
-    def _image(self, path, (x, y), alpha, pageNumber):
+    def _image(self, path, xy, alpha, pageNumber):
+        x, y = xy
         self._save()
         _isPDF, image = self._getImageSource(path, pageNumber)
         if image is not None:
@@ -382,7 +385,8 @@ class PDFContext(BaseContext):
             return Quartz.CGColorCreateGenericGray(c.whiteComponent(), c.alphaComponent())
         return Quartz.CGColorCreateGenericRGB(c.redComponent(), c.greenComponent(), c.blueComponent(), c.alphaComponent())
 
-    def _linkDestination(self, name, (x, y)):
+    def _linkDestination(self, name, xy):
+        x, y = xy
         if (x, y) == (None, None):
             x, y = self.width * 0.5, self.height * 0.5
         x = max(0, min(x, self.width))
@@ -390,6 +394,7 @@ class PDFContext(BaseContext):
         centerPoint = Quartz.CGPoint(x, y)
         Quartz.CGPDFContextAddDestinationAtPoint(self._pdfContext, name, centerPoint)
 
-    def _linkRect(self, name, (x, y, w, h)):
+    def _linkRect(self, name, xywh):
+        x, y, w, h = xywh
         rectBox = Quartz.CGRectMake(x, y, w, h)
         Quartz.CGPDFContextSetDestinationForRect(self._pdfContext, name, rectBox)

--- a/drawBot/context/printContext.py
+++ b/drawBot/context/printContext.py
@@ -1,4 +1,6 @@
-from baseContext import BaseContext
+from __future__ import absolute_import, print_function
+
+from .baseContext import BaseContext
 
 
 class PrintContext(BaseContext):
@@ -6,46 +8,50 @@ class PrintContext(BaseContext):
     fileExtensions = ["*"]
 
     def _newPage(self, width, height):
-        print "newPage", width, height
+        print("newPage", width, height)
 
     def _save(self):
-        print "save"
+        print("save")
 
     def _restore(self):
-        print "restore"
+        print("restore")
 
     def _blendMode(self, operation):
-        print "blend mode", operation
+        print("blend mode", operation)
 
     def _drawPath(self):
-        print "drawPath", self._state.path
+        print("drawPath", self._state.path)
 
     def _clipPath(self):
-        print "clipPath", self._state.path
+        print("clipPath", self._state.path)
 
     def _transform(self, matrix):
-        print "transform", matrix
+        print("transform", matrix)
 
-    def _textBox(self, txt, (x, y, w, h), align):
-        print "textBox", txt, (x, y, w, h), align
+    def _textBox(self, txt, xywh, align):
+        x, y, w, h = xywh
+        print("textBox", txt, (x, y, w, h), align)
 
-    def _image(self, path, (x, y), alpha, pageNumber):
-        print "image", path, x, y, alpha, pageNumber
+    def _image(self, path, xy, alpha, pageNumber):
+        x, y = xy
+        print("image", path, x, y, alpha, pageNumber)
 
     def _frameDuration(self, seconds):
-        print "frameDuration", seconds
+        print("frameDuration", seconds)
 
     def _reset(self, other=None):
-        print "reset", other
+        print("reset", other)
 
     def _saveImage(self, path, multipage):
-        print "saveImage", path, multipage
+        print("saveImage", path, multipage)
 
     def _printImage(self, pdf=None):
-        print "printImage", pdf
+        print("printImage", pdf)
 
-    def _linkDestination(self, name, (x, y)):
-        print "linkDestination", name, (x, y)
+    def _linkDestination(self, name, xy):
+        x, y = xy
+        print("linkDestination", name, (x, y))
 
-    def _linkRect(self, name, (x, y, w, h)):
-        print "linkRect", name, (x, y, w, h)
+    def _linkRect(self, name, xywh):
+        x, y, w, h = xywh
+        print("linkRect", name, (x, y, w, h))

--- a/drawBot/context/svgContext.py
+++ b/drawBot/context/svgContext.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import AppKit
 import CoreText
 
@@ -10,8 +12,8 @@ from fontTools.misc.xmlWriter import XMLWriter
 
 from fontTools.misc.transform import Transform
 
-from tools.openType import getFeatureTagsForFontAttributes
-from baseContext import BaseContext, GraphicsState, Shadow, Color, FormattedString, Gradient
+from .tools.openType import getFeatureTagsForFontAttributes
+from .baseContext import BaseContext, GraphicsState, Shadow, Color, FormattedString, Gradient
 
 from drawBot.misc import warnings, formatNumber
 
@@ -433,10 +435,11 @@ class SVGContext(BaseContext):
         self._svgContext.newline()
         self._svgEndClipPath()
 
-    def _image(self, path, (x, y), alpha, pageNumber):
+    def _image(self, path, xy, alpha, pageNumber):
         # todo:
         # support embedding of images when the source is not a path but
         # a nsimage or a pdf / gif with a pageNumber
+        x, y = xy
         self._svgBeginClipPath()
         if path.startswith("http"):
             url = AppKit.NSURL.URLWithString_(path)

--- a/drawBot/context/tools/imageObject.py
+++ b/drawBot/context/tools/imageObject.py
@@ -3,6 +3,7 @@ from math import radians
 import os
 
 from drawBot.misc import DrawBotError, optimizePath
+from fontTools.misc.py23 import basestring
 
 
 class ImageObject(object):
@@ -55,7 +56,7 @@ class ImageObject(object):
         """
         if isinstance(path, AppKit.NSImage):
             im = path
-        elif isinstance(path, (str, unicode)):
+        elif isinstance(path, basestring):
             path = optimizePath(path)
             if path.startswith("http"):
                 url = AppKit.NSURL.URLWithString_(path)

--- a/drawBot/drawBotDrawingTools.py
+++ b/drawBot/drawBotDrawingTools.py
@@ -79,7 +79,7 @@ class DrawBotDrawingTool(object):
 
     def _get_version(self):
         try:
-            import drawBotSettings
+            from drawBot import drawBotSettings
             return drawBotSettings.__version__
         except Exception:
             pass
@@ -354,7 +354,7 @@ class DrawBotDrawingTool(object):
                     # draw an oval in each of them
                     oval(110, 10, 30, 30)
         """
-        from drawBotPageDrawingTools import DrawBotPage
+        from .drawBotPageDrawingTools import DrawBotPage
         instructions = []
         for instructionSet in self._instructionsStack:
             for callback, _, _ in instructionSet:
@@ -439,7 +439,7 @@ class DrawBotDrawingTool(object):
         """
         Return the image as a pdf document object.
         """
-        from context.drawBotContext import DrawBotContext
+        from .context.drawBotContext import DrawBotContext
         context = DrawBotContext()
         self._drawInContext(context)
         return context.getNSPDFDocument()

--- a/drawBot/drawBotDrawingTools.py
+++ b/drawBot/drawBotDrawingTools.py
@@ -1307,7 +1307,7 @@ class DrawBotDrawingTool(object):
             font("Times-Italic")
         """
         fontName = self._tryInstallFontFromFontName(fontName)
-        fontName = fontName.encode("ascii", "ignore").decode("ascii")
+        fontName = str(fontName)
         self._dummyContext.font(fontName, fontSize)
         self._addInstruction("font", fontName, fontSize)
         return fontName
@@ -1321,7 +1321,7 @@ class DrawBotDrawingTool(object):
             fallbackFont("Times")
         """
         fontName = self._tryInstallFontFromFontName(fontName)
-        fontName = fontName.encode("ascii", "ignore").decode("ascii")
+        fontName = str(fontName)
         dummyFont = AppKit.NSFont.fontWithName_size_(fontName, 10)
         if dummyFont is None:
             raise DrawBotError("Fallback font '%s' is not available" % fontName)

--- a/drawBot/drawBotDrawingTools.py
+++ b/drawBot/drawBotDrawingTools.py
@@ -17,7 +17,7 @@ from .context.tools import gifTools
 
 from .misc import DrawBotError, warnings, VariableController, optimizePath, isPDF, isEPS, isGIF
 
-from fontTools.misc.py23 import basestring
+from fontTools.misc.py23 import basestring, PY2
 
 
 def _getmodulecontents(module, names=None):
@@ -1307,7 +1307,7 @@ class DrawBotDrawingTool(object):
             font("Times-Italic")
         """
         fontName = self._tryInstallFontFromFontName(fontName)
-        fontName = fontName.encode("ascii", "ignore")
+        fontName = fontName.encode("ascii", "ignore").decode("ascii")
         self._dummyContext.font(fontName, fontSize)
         self._addInstruction("font", fontName, fontSize)
         return fontName
@@ -1321,7 +1321,7 @@ class DrawBotDrawingTool(object):
             fallbackFont("Times")
         """
         fontName = self._tryInstallFontFromFontName(fontName)
-        fontName = fontName.encode("ascii", "ignore")
+        fontName = fontName.encode("ascii", "ignore").decode("ascii")
         dummyFont = AppKit.NSFont.fontWithName_size_(fontName, 10)
         if dummyFont is None:
             raise DrawBotError("Fallback font '%s' is not available" % fontName)
@@ -1575,7 +1575,7 @@ class DrawBotDrawingTool(object):
             font("Times-Italic")
             text("hallo, I'm Times", (100, 100))
         """
-        if isinstance(txt, (str, unicode)):
+        if PY2 and isinstance(txt, basestring):
             try:
                 txt = txt.decode("utf-8")
             except UnicodeEncodeError:
@@ -1618,7 +1618,7 @@ class DrawBotDrawingTool(object):
         Optionally `txt` can be a `FormattedString`.
         Optionally `box` can be a `BezierPath`.
         """
-        if isinstance(txt, (str, unicode)):
+        if PY2 and isinstance(txt, basestring):
             try:
                 txt = txt.decode("utf-8")
             except UnicodeEncodeError:
@@ -1751,7 +1751,7 @@ class DrawBotDrawingTool(object):
             # draw some text in the path
             textBox("abcdefghijklmnopqrstuvwxyz"*30000, path)
         """
-        if isinstance(txt, (str, unicode)):
+        if PY2 and isinstance(txt, basestring):
             try:
                 txt = txt.decode("utf-8")
             except UnicodeEncodeError:
@@ -1779,7 +1779,7 @@ class DrawBotDrawingTool(object):
         Optionally an alignment can be set.
         Possible `align` values are: `"left"`, `"center"`, `"right"` and `"justified"`.
         """
-        if isinstance(txt, (str, unicode)):
+        if PY2 and isinstance(txt, basestring):
             try:
                 txt = txt.decode("utf-8")
             except UnicodeEncodeError:
@@ -1859,7 +1859,7 @@ class DrawBotDrawingTool(object):
             alpha = 1
         if isinstance(path, self._imageClass):
             path = path._nsImage()
-        if isinstance(path, (str, unicode)):
+        if isinstance(path, basestring):
             path = optimizePath(path)
         self._requiresNewFirstPage = True
         self._addInstruction("image", path, (x, y), alpha, pageNumber)
@@ -1882,7 +1882,7 @@ class DrawBotDrawingTool(object):
             # its an NSImage
             rep = path
         else:
-            if isinstance(path, (str, unicode)):
+            if isinstance(path, basestring):
                 path = optimizePath(path)
             if path.startswith("http"):
                 url = AppKit.NSURL.URLWithString_(path)
@@ -1952,7 +1952,7 @@ class DrawBotDrawingTool(object):
                         text("W", (x, y))
         """
         x, y = xy
-        if isinstance(path, (str, unicode)):
+        if isinstance(path, basestring):
             path = optimizePath(path)
         bitmap = _chachedPixelColorBitmaps.get(path)
         if bitmap is None:
@@ -2082,7 +2082,7 @@ class DrawBotDrawingTool(object):
         Optionally a `width` constrain or `height` constrain can be provided
         to calculate the lenght or width of text with the given constrain.
         """
-        if isinstance(txt, (str, unicode)):
+        if PY2 and isinstance(txt, basestring):
             try:
                 txt = txt.decode("utf-8")
             except UnicodeEncodeError:

--- a/drawBot/drawBotSettings.py
+++ b/drawBot/drawBotSettings.py
@@ -1,4 +1,9 @@
+import sys
 
-appName = "DrawBot"
+if sys.version_info[0] >= 3:
+    appName = "DrawBotPy3"
+else:
+    appName = "DrawBot"
+
 
 __version__ = "3.102"

--- a/drawBot/scriptTools.py
+++ b/drawBot/scriptTools.py
@@ -163,7 +163,7 @@ class ScriptRunner(object):
     def __init__(self, text=None, path=None, stdout=None, stderr=None, namespace=None, checkSyntaxOnly=False):
         from threading import Thread
         if path:
-            if isinstance(path, unicode):
+            if PY2 and isinstance(path, unicode):
                 path = path.encode("utf-8")
             curDir, fileName = os.path.split(path)
         else:

--- a/drawBot/scriptTools.py
+++ b/drawBot/scriptTools.py
@@ -13,6 +13,8 @@ from vanilla.vanillaBase import osVersion10_10, osVersionCurrent
 
 from drawBot.misc import getDefault
 
+from fontTools.misc.py23 import PY2
+
 
 class StdOutput(object):
 
@@ -23,7 +25,7 @@ class StdOutput(object):
         self._previousFlush = time.time()
 
     def write(self, data):
-        if isinstance(data, str):
+        if PY2 and isinstance(data, str):
             try:
                 data = unicode(data, "utf-8", "replace")
             except UnicodeDecodeError:
@@ -219,7 +221,7 @@ class ScriptRunner(object):
                 if not checkSyntaxOnly:
                     self._scriptDone = False
                     try:
-                        exec code in namespace
+                        exec(code, namespace)
                     except KeyboardInterrupt:
                         pass
                     except:

--- a/drawBot/scriptTools.py
+++ b/drawBot/scriptTools.py
@@ -87,30 +87,21 @@ def _execute(cmds):
     return stderr, stdout
 
 
-getLocalPythonPathCode = u"""
-from distutils import sysconfig
-
-_path = sysconfig.get_python_lib(%s)
-
-print _path
-"""
-
-
 def getLocalPythonVersionDirName(standardLib=True):
-    tempFile = tempfile.mkstemp(".py")[1]
     argument = ""
     if standardLib:
         argument = "standard_lib=True"
-    f = open(tempFile, "w")
-    f.write(getLocalPythonPathCode % argument)
-    f.close()
-    log = _execute(["python", tempFile])[1]
-    sitePackages = log.split("\n")[0]
-    os.remove(tempFile)
+    if PY2:
+        python = "python"
+    else:
+        python = "python3"
+    commands = [python, "-c", "from distutils import sysconfig; print(sysconfig.get_python_lib(%s))" % argument]
+    err, out = _execute(commands)
+    sitePackages = out.split("\n")[0]
     if os.path.exists(sitePackages):
         return sitePackages
     else:
-        return False
+        return None
 
 
 localStandardLibPath = getLocalPythonVersionDirName(standardLib=True)

--- a/drawBot/ui/codeEditor.py
+++ b/drawBot/ui/codeEditor.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import AppKit
 
 from keyword import kwlist
@@ -16,8 +18,9 @@ except Exception:
     hasJedi = False
 
 from vanilla import *
+from vanilla.py23 import python_method
 
-from lineNumberRulerView import NSLineNumberRuler
+from .lineNumberRulerView import NSLineNumberRuler
 from drawBot.misc import getDefault, getFontDefault, getColorDefault, DrawBotError
 from drawBot.drawBotDrawingTools import _drawBotDrawingTool
 
@@ -178,9 +181,9 @@ def _hexStringToNSColor(txt, default=AppKit.NSColor.blackColor()):
 
 def _NSColorToHexString(color):
     color = color.colorUsingColorSpaceName_(AppKit.NSCalibratedRGBColorSpace)
-    r = color.redComponent() * 255
-    g = color.greenComponent() * 255
-    b = color.blueComponent() * 255
+    r = round(color.redComponent() * 255)
+    g = round(color.greenComponent() * 255)
+    b = round(color.blueComponent() * 255)
     return "#%02X%02X%02X" % (r, g, b)
 
 
@@ -500,6 +503,7 @@ class CodeNSTextView(AppKit.NSTextView):
         self._highlightSyntax(0, self.string())
         self._ignoreProcessEditing = False
 
+    @python_method
     def _highlightSyntax(self, location, text):
         if self.lexer() is None:
             return
@@ -784,6 +788,7 @@ class CodeNSTextView(AppKit.NSTextView):
         func = languageData.get("wordCompletions", self._genericCompletions)
         return func(text, charRange)
 
+    @python_method
     def _genericCompletions(self, text, charRange):
         partialString = text.substringWithRange_(charRange)
         keyWords = list()
@@ -941,6 +946,7 @@ class CodeNSTextView(AppKit.NSTextView):
             return commentedLines
         self._filterLines(uncommentFilter)
 
+    @python_method
     def _jumpToLine(self, lineNumber):
         lines = 1
         string = self.string()
@@ -1049,6 +1055,7 @@ class CodeNSTextView(AppKit.NSTextView):
                 backgroundColor = _hexStringToNSColor(styles.background_color, self._fallbackBackgroundColor)
                 ruler.setRulerBackgroundColor_(backgroundColor)
 
+    @python_method
     def _deleteIndentation(self, sender, isForward, superFunc):
         selectedRange = self.selectedRange()
         if self.usesTabs() or selectedRange.length:
@@ -1074,6 +1081,7 @@ class CodeNSTextView(AppKit.NSTextView):
         else:
             superFunc(sender)
 
+    @python_method
     def _findMatchingParen(self, location, char, matchChar, end):
         add = 1
         if end:
@@ -1095,6 +1103,7 @@ class CodeNSTextView(AppKit.NSTextView):
             location += add
         return found
 
+    @python_method
     def _balanceParenForChar(self, char, location):
         if self.lexer() is None:
             return
@@ -1108,6 +1117,7 @@ class CodeNSTextView(AppKit.NSTextView):
             openToCloseMap = _reverseMap(openToCloseMap)
             self._balanceParens(location=location, char=char, matchChar=openToCloseMap[char], end=True)
 
+    @python_method
     def _balanceParens(self, location, char, matchChar, end):
         found = self._findMatchingParen(location, char, matchChar, end)
         if found is not None:
@@ -1126,9 +1136,11 @@ class CodeNSTextView(AppKit.NSTextView):
             self.layoutManager().setTemporaryAttributes_forCharacterRange_(balancingAttrs, (found, 1))
             self.performSelector_withObject_afterDelay_("_resetBalanceParens:", (oldAttrs, effRng), 0.2)
 
-    def _resetBalanceParens_(self, (attrs, rng)):
+    def _resetBalanceParens_(self, attrs_rng):
+        attrs, rng = attrs_rng
         self.layoutManager().setTemporaryAttributes_forCharacterRange_(attrs, rng)
 
+    @python_method
     def _filterLines(self, filterFunc):
         selectedRange = self.selectedRange()
         lines, linesRange = self._getTextForRange(selectedRange)
@@ -1143,6 +1155,7 @@ class CodeNSTextView(AppKit.NSTextView):
         newSelRng = linesRange.location, len(filteredLines)
         self.setSelectedRange_(newSelRng)
 
+    @python_method
     def _getLeftWordRange(self, newRange):
         if newRange.location == 0:
             return 0
@@ -1169,6 +1182,7 @@ class CodeNSTextView(AppKit.NSTextView):
 
         return location
 
+    @python_method
     def _getRightWordRange(self, newRange):
         text = self.string()
         lenText = len(text)
@@ -1192,11 +1206,13 @@ class CodeNSTextView(AppKit.NSTextView):
                     isChar = not isChar
         return location
 
+    @python_method
     def _getTextForRange(self, lineRange):
         string = self.string()
         lineRange = string.lineRangeForRange_(lineRange)
         return string.substringWithRange_(lineRange), lineRange
 
+    @python_method
     def _getSelectedValueForRange(self, selectedRange):
         value = None
         try:
@@ -1209,12 +1225,14 @@ class CodeNSTextView(AppKit.NSTextView):
             pass
         return value
 
+    @python_method
     def _insertTextAndRun(self, txt, txtRange):
         self.insertText_(txt)
         newRange = AppKit.NSMakeRange(txtRange.location, len(txt))
         self.setSelectedRange_(newRange)
         return self._runInternalCode()
 
+    @python_method
     def _runInternalCode(self):
         pool = AppKit.NSAutoreleasePool.alloc().init()
         try:

--- a/drawBot/ui/codeEditor.py
+++ b/drawBot/ui/codeEditor.py
@@ -1220,7 +1220,7 @@ class CodeNSTextView(AppKit.NSTextView):
             for c in txt:
                 if c not in "0123456789.,- ":
                     raise DrawBotError("No dragging possible")
-            exec("value = %s" % txt)
+            value = eval(txt)
         except Exception:
             pass
         return value

--- a/drawBot/ui/codeEditor.py
+++ b/drawBot/ui/codeEditor.py
@@ -19,6 +19,7 @@ except Exception:
 
 from vanilla import *
 from vanilla.py23 import python_method
+from fontTools.misc.py23 import PY3
 
 from .lineNumberRulerView import NSLineNumberRuler
 from drawBot.misc import getDefault, getFontDefault, getColorDefault, DrawBotError
@@ -299,6 +300,8 @@ languagesIDEBehavior = {
         "dropPathsSeperator": ", "
     },
 }
+if PY3:
+    languagesIDEBehavior["Python"]["dropPathFormatting"] = '%r'
 
 downArrowSelectionDirection = 0
 upArrowSelectionDirection = 1

--- a/drawBot/ui/codeEditor.py
+++ b/drawBot/ui/codeEditor.py
@@ -19,7 +19,7 @@ except Exception:
 
 from vanilla import *
 from vanilla.py23 import python_method
-from fontTools.misc.py23 import PY3
+from fontTools.misc.py23 import PY3, unichr
 
 from .lineNumberRulerView import NSLineNumberRuler
 from drawBot.misc import getDefault, getFontDefault, getColorDefault, DrawBotError

--- a/drawBot/ui/debug.py
+++ b/drawBot/ui/debug.py
@@ -1,10 +1,12 @@
+from __future__ import absolute_import
+
 from AppKit import *
 
 import sys
 
 from vanilla import *
 
-from codeEditor import OutPutEditor
+from .codeEditor import OutPutEditor
 
 
 class ShowHideNSPanel(NSPanel):

--- a/drawBot/ui/drawBotController.py
+++ b/drawBot/ui/drawBotController.py
@@ -1,16 +1,18 @@
+from __future__ import absolute_import
+
 import AppKit
 from vanilla import *
 from defconAppKit.windows.baseWindow import BaseWindowController
 
-from codeEditor import CodeEditor, OutPutEditor
-from drawView import DrawView, ThumbnailView
+from .codeEditor import CodeEditor, OutPutEditor
+from .drawView import DrawView, ThumbnailView
 
 from drawBot.scriptTools import ScriptRunner, CallbackRunner, DrawBotNamespace, StdOutput
 from drawBot.drawBotDrawingTools import _drawBotDrawingTool
 from drawBot.context.drawBotContext import DrawBotContext
 from drawBot.misc import getDefault, setDefault, warnings
 
-from splitView import SplitView
+from .splitView import SplitView
 
 
 class DrawBotController(BaseWindowController):

--- a/drawBot/ui/drawBotController.py
+++ b/drawBot/ui/drawBotController.py
@@ -184,7 +184,7 @@ class DrawBotController(BaseWindowController):
         Sets the content of a file into the code view.
         """
         # open a file
-        f = open(path)
+        f = open(path, "rb")
         # read the content
         code = f.read().decode("utf-8")
         # close the file

--- a/drawBot/ui/lineNumberRulerView.py
+++ b/drawBot/ui/lineNumberRulerView.py
@@ -134,7 +134,7 @@ class NSLineNumberRuler(NSRulerView):
         right = len(lines)
 
         while (right - left) > 1:
-            mid = (right + left) / 2
+            mid = (right + left) // 2
             lineStart = lines[mid]
 
             if index < lineStart:

--- a/drawBot/ui/preferencesController.py
+++ b/drawBot/ui/preferencesController.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from AppKit import *
 
 from vanilla import *
@@ -6,7 +8,7 @@ from defconAppKit.windows.baseWindow import BaseWindowController
 
 from drawBot.misc import getDefault, setDefault, getFontDefault, setFontDefault, getColorDefault, setColorDefault
 
-from codeEditor import _textAttributesForStyle, _hexToNSColor, fallbackBackgroundColor, fallbackHightLightColor, fallbackFont, styleFromDefault, fallbackStyles
+from .codeEditor import _textAttributesForStyle, _hexToNSColor, fallbackBackgroundColor, fallbackHightLightColor, fallbackFont, styleFromDefault, fallbackStyles
 
 
 class ColorCell(NSActionCell):

--- a/drawBot/updater.py
+++ b/drawBot/updater.py
@@ -1,4 +1,9 @@
-import urllib2
+from __future__ import absolute_import, print_function
+
+try:
+    from urllib2 import urlopen
+except ImportError:
+    from urllib.request import urlopen
 import subprocess
 import plistlib
 import AppKit
@@ -9,7 +14,7 @@ import vanilla
 from defconAppKit.windows.progressWindow import ProgressWindow
 
 from drawBot import __version__
-from misc import DrawBotError, getDefault
+from .misc import DrawBotError, getDefault
 
 
 def getCurrentVersion():
@@ -20,7 +25,7 @@ def getCurrentVersion():
         return ""
     path = "https://raw.github.com/typemytype/drawbot/master/drawBot/drawBotSettings.py"
     try:
-        response = urllib2.urlopen(path, timeout=5)
+        response = urlopen(path, timeout=5)
         code = response.read()
         response.close()
         exec(code)
@@ -49,7 +54,7 @@ def downloadCurrentVersion():
                 break
         AppKit.NSWorkspace.sharedWorkspace().openFile_(dmgPath)
     except:
-        print "Something went wrong while downloading %s" % path
+        print("Something went wrong while downloading %s" % path)
 
 
 class Updater(object):

--- a/drawBot/updater.py
+++ b/drawBot/updater.py
@@ -16,6 +16,8 @@ from defconAppKit.windows.progressWindow import ProgressWindow
 from drawBot import __version__
 from .misc import DrawBotError, getDefault
 
+from fontTools.misc.py23 import unichr
+
 
 def getCurrentVersion():
     """

--- a/drawBot/updater.py
+++ b/drawBot/updater.py
@@ -16,7 +16,7 @@ from defconAppKit.windows.progressWindow import ProgressWindow
 from drawBot import __version__
 from .misc import DrawBotError, getDefault
 
-from fontTools.misc.py23 import unichr
+from fontTools.misc.py23 import unichr, PY2
 
 
 def getCurrentVersion():
@@ -40,7 +40,10 @@ def downloadCurrentVersion():
     """
     Download the current version (dmg) and mount it
     """
-    path = "http://static.typemytype.com/drawBot/DrawBot.dmg"
+    if PY2:
+        path = "http://static.typemytype.com/drawBot/DrawBot.dmg"
+    else:
+        path = "http://static.typemytype.com/drawBot/DrawBotPy3.dmg"
     try:
         # download and mount
         cmds = ["hdiutil", "attach", "-plist", path]

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from distutils.core import setup
 from distutils import sysconfig
 import py2app
@@ -139,53 +141,53 @@ if "-A" not in sys.argv:
     # copy external tools into the resources folder (gifsicle)
     gifsiclePathSource = os.path.join(os.getcwd(), "drawBot", "context", "tools", "gifsicle")
     gifsiclePathDest = os.path.join(appLocation, "contents", "Resources", "gifsicle")
-    print "copy", gifsiclePathSource, gifsiclePathDest
+    print("copy", gifsiclePathSource, gifsiclePathDest)
     shutil.copyfile(gifsiclePathSource, gifsiclePathDest)
-    os.chmod(gifsiclePathDest, 0775)
+    os.chmod(gifsiclePathDest, 0o775)
 
     mkbitmapPathSource = os.path.join(os.getcwd(), "drawBot", "context", "tools", "mkbitmap")
     mkbitmapPathDest = os.path.join(appLocation, "contents", "Resources", "mkbitmap")
-    print "copy", mkbitmapPathSource, mkbitmapPathDest
+    print("copy", mkbitmapPathSource, mkbitmapPathDest)
     shutil.copyfile(mkbitmapPathSource, mkbitmapPathDest)
-    os.chmod(mkbitmapPathDest, 0775)
+    os.chmod(mkbitmapPathDest, 0o775)
 
     potracePathSource = os.path.join(os.getcwd(), "drawBot", "context", "tools", "potrace")
     potracePathDest = os.path.join(appLocation, "contents", "Resources", "potrace")
-    print "copy", potracePathSource, potracePathDest
+    print("copy", potracePathSource, potracePathDest)
     shutil.copyfile(potracePathSource, potracePathDest)
-    os.chmod(potracePathDest, 0775)
+    os.chmod(potracePathDest, 0o775)
 
     if codeSignDeveloperName:
         # ================
         # = code singing =
         # ================
-        print "---------------------"
-        print "-   code signing    -"
+        print("---------------------")
+        print("-   code signing    -")
         cmds = ["codesign", "--force", "--deep", "--sign", "Developer ID Application: %s" % codeSignDeveloperName, appLocation]
         popen = subprocess.Popen(cmds)
         popen.wait()
-        print "- done code singing -"
-        print "---------------------"
+        print("- done code singing -")
+        print("---------------------")
 
-        print "------------------------------"
-        print "- verifying with codesign... -"
+        print("------------------------------")
+        print("- verifying with codesign... -")
         cmds = ["codesign", "--verify", "--verbose=4", appLocation]
         popen = subprocess.Popen(cmds)
         popen.wait()
-        print "------------------------------"
+        print("------------------------------")
 
-        print "---------------------------"
-        print "- verifying with spctl... -"
+        print("---------------------------")
+        print("- verifying with spctl... -")
         cmds = ["spctl", "--verbose=4", "--raw", "--assess", "--type", "execute", appLocation]
         popen = subprocess.Popen(cmds)
         popen.wait()
-        print "---------------------------"
+        print("---------------------------")
 
     # ================
     # = creating dmg =
     # ================
-    print "------------------------"
-    print "-    building dmg...   -"
+    print("------------------------")
+    print("-    building dmg...   -")
     if os.path.exists(existingDmgLocation):
         os.remove(existingDmgLocation)
 
@@ -203,13 +205,13 @@ if "-A" not in sys.argv:
 
     shutil.rmtree(imgLocation)
 
-    print "- done building dmg... -"
-    print "------------------------"
+    print("- done building dmg... -")
+    print("------------------------")
 
     if ftpHost and ftpPath and ftpLogin and ftpPassword:
         import ftplib
-        print "-------------------------"
-        print "-    uploading to ftp   -"
+        print("-------------------------")
+        print("-    uploading to ftp   -")
         session = ftplib.FTP(ftpHost, ftpLogin, ftpPassword)
         session.cwd(ftpPath)
 
@@ -226,6 +228,6 @@ if "-A" not in sys.argv:
         session.storbinary('STOR %s' % fileName, dmgFile)
         dmgFile.close()
 
-        print "- done uploading to ftp -"
-        print "-------------------------"
+        print("- done uploading to ftp -")
+        print("-------------------------")
         session.quit()

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ for fileName in os.listdir("Resources/Images"):
 
 # build
 setup(
+    name=appName,
     data_files=dataFiles,
     app=[dict(script="DrawBot.py", plist=plist)],
     options=dict(
@@ -125,7 +126,7 @@ setup(
 )
 
 # fix the icon
-path = os.path.join(os.path.dirname(__file__), "dist", "DrawBot.app", "Contents", "Info.plist")
+path = os.path.join(os.path.dirname(__file__), "dist", "%s.app" % appName, "Contents", "Info.plist")
 appPlist = readPlist(path)
 appPlist["CFBundleIconFile"] = "DrawBot.icns"
 writePlist(appPlist, path)


### PR DESCRIPTION
*** This has only been lightly tested. ***

It's a simple port: you build DrawBot either with Python 2.7, and then you code DB with 2.7, or you build it with Python 3.6.*, and then you code DB with that version of Python.

Things to look into:
- how does importing external module work, if at all?
- I didn't touch the auto updater, so that may cause some trouble

It would be nice to offer it as an experimental download at drawbot.com, named DrawBotPy3.app.