### PR TITLE
simplify adding local sys paths, and take it out of the script runner

### DIFF
--- a/drawBot/scriptTools.py
+++ b/drawBot/scriptTools.py
@@ -14,7 +14,7 @@ from vanilla.vanillaBase import osVersion10_10, osVersionCurrent
 
 from fontTools.misc.py23 import PY2, PY3
 
-from drawBot.misc import getDefault, executeExternalProcess
+from drawBot.misc import getDefault
 
 
 class StdOutput(object):


### PR DESCRIPTION
This fixes #134, but makes it a little less general.

For Python 2.7: assume we're running the `/System` Python. For Python 3: assume the standard OSX install from python.org.

Adding of site dirs is now happening upon import of scriptTools.py. It's a global operation, and it doesn't make sense to do it everytime a script is executed.