### PR TITLE
While a script is running, run a thread to monitor command-period

### DIFF
--- a/drawBot/scriptTools.py
+++ b/drawBot/scriptTools.py
@@ -134,8 +134,8 @@ def ScriptRunner(text=None, path=None, stdout=None, stderr=None, namespace=None,
         while not scriptDone:  # scriptDone is in the surrounding scope
             if CheckEventQueueForUserCancel():
                 # Send a SIGINT signal to ourselves.
-                # This gets delivered to the main thread,
-                # cancelling the running script.
+                # This gets delivered to the main thread as a KeyboardInterrupt
+                # exception, cancelling the running script.
                 with cancelLock:
                     os.kill(os.getpid(), SIGINT)
                 break


### PR DESCRIPTION
...and interrupt the main thread if the user indeed wants to cancel the execution of the script.

This pulls in a function from Carbon.framework via ctypes. I'm not sure how future-proof that is. But so far, this works like a champ.