### PR TITLE
Adds a memoize decorator to cache frequently used getter functions

### DIFF
--- a/drawBot/context/tools/openType.py
+++ b/drawBot/context/tools/openType.py
@@ -1,4 +1,5 @@
 import CoreText
+from drawBot.misc import memoize
 
 # https://developer.apple.com/fonts/TrueType-Reference-Manual/RM09/AppendixF.html
 # https://github.com/behdad/harfbuzz/blob/master/src/hb-coretext.cc#L381
@@ -470,12 +471,14 @@ for key, value in _featureMap.items():
     reversedFeatureMap[(featureType, featureSelector)] = key
 
 
+@memoize
 def getFeatureTagForFontAttribute(attribute):
     featureType = attribute.get(CoreText.NSFontFeatureTypeIdentifierKey)
     featureSelector = attribute.get(CoreText.NSFontFeatureSelectorIdentifierKey)
     return reversedFeatureMap.get((featureType, featureSelector))
 
 
+@memoize
 def getFeatureTagsForFontAttributes(attributes):
     featureTags = list()
     for attribute in attributes:
@@ -485,6 +488,7 @@ def getFeatureTagsForFontAttributes(attributes):
     return featureTags
 
 
+@memoize
 def getFeatureTagsForDescriptions(featureDescriptions):
     featureTags = dict()
     for featureDescription in featureDescriptions:
@@ -498,6 +502,7 @@ def getFeatureTagsForDescriptions(featureDescriptions):
     return featureTags
 
 
+@memoize
 def getFeatureTagsForFontName(fontName):
     descriptor = CoreText.NSFontDescriptor.fontDescriptorWithName_size_(fontName, 12)
     featureDescriptions = CoreText.CTFontDescriptorCopyAttribute(descriptor, CoreText.kCTFontFeaturesAttribute)

--- a/drawBot/context/tools/variation.py
+++ b/drawBot/context/tools/variation.py
@@ -1,5 +1,6 @@
 import CoreText
 from collections import OrderedDict
+from drawBot.misc import memoize
 
 """
 https://developer.apple.com/documentation/coretext/ctfont/font_variation_axis_dictionary_keys?language=objc
@@ -7,6 +8,7 @@ https://developer.apple.com/documentation/coretext/1508650-ctfontdescriptorcreat
 """
 
 
+@memoize
 def convertIntToVariationTag(value):
     chars = []
     for shift in range(4):
@@ -14,6 +16,7 @@ def convertIntToVariationTag(value):
     return "".join(reversed(chars))
 
 
+@memoize
 def convertVariationTagToInt(tag):
     assert len(tag) == 4
     i = 0
@@ -23,6 +26,7 @@ def convertVariationTagToInt(tag):
     return i
 
 
+@memoize
 def getVariationAxesForFontName(fontName):
     axes = OrderedDict()
     font = CoreText.CTFontCreateWithName(fontName, 12, None)

--- a/drawBot/misc.py
+++ b/drawBot/misc.py
@@ -325,6 +325,30 @@ def getExternalToolPath(root, toolName):
     return toolPath
 
 
+def memoize(function):
+    """
+    Memoize a function's return value with the function's arguments.
+    The next time a function is called with the same arguments, the cache is returned. 
+
+    Example usage:
+        @memoize
+        def addNumbers(first, second):
+            return first + second
+        # The first time this function is called the calculation will be made,
+        # and and the result will be stored in the cache dict as [first, second]: returnValue
+        # From then on, this value will be returned when the same argument is made to the addNumbers function
+    """
+    saved = {}
+    def wrapper(*args):
+        if args in saved:
+            return saved[args]
+        else:
+            rv = function(*args)
+            saved[args] = rv
+            return rv
+    return wrapper
+
+
 if __name__ == "__main__":
     import doctest
     doctest.testmod()


### PR DESCRIPTION
I noticed that the last commit in "master" slowed down some larger proofs of mine, I think the problem is just that it needs to repeatedly call some helper functions in openType.py every time you append to a FormattedString.

Would you consider a fix like you find in this commit, that uses a memoize decorator to cache the results? It's one that I had found somewhere in the past and have been using in my own code.

I think this is safe to cache the results from these "get" functions since the font isn't going to change while the script is running.

Example script:

```python
import drawBot as db
import time

fs = db.FormattedString()
runs = 100
totalTime = 0
for i in range(runs):
    now = time.time()
    fs.append("Test", font="Operator-Medium", openTypeFeatures=dict(smcp=True, liga=True))
    totalTime += (time.time() - now)
print totalTime/runs
```
With this script, the timer reports:
``0.0019614815712`` seconds with commit d924098 (before OT feature changes)
``0.0038596010208`` seconds with fd27983 (latest master)
``0.0001614809036`` with caching in openType.py and variations.py

The difference might seem trivial, but a very very large proof now goes from taking 154 seconds to draw, down to 44 seconds. Nice!
