### PR TITLE
FormattedString clear method onlyText argument

### DIFF
--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -902,8 +902,11 @@ class FormattedString(object):
         result.update(attributes)
         return result
 
-    def clear(self):
-        self._attributedString = AppKit.NSMutableAttributedString.alloc().init()
+    def clear(self, onlyText=False):
+        if onlyText:
+            self._attributedString.replaceCharactersInRange_withString_((0, self._attributedString.length() - 1), "")
+        else:
+            self._attributedString = AppKit.NSMutableAttributedString.alloc().init()
 
     def append(self, txt, **kwargs):
         """

--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -904,7 +904,7 @@ class FormattedString(object):
 
     def clear(self, onlyText=False):
         if onlyText:
-            self._attributedString.replaceCharactersInRange_withString_((0, self._attributedString.length() - 1), "")
+            self._attributedString.replaceCharactersInRange_withString_((0, self._attributedString.length()), "")
         else:
             self._attributedString = AppKit.NSMutableAttributedString.alloc().init()
 


### PR DESCRIPTION
It would be convenient if it was possible to only clear the text inside the attrubtedString and keep all the format styles.