### PR TITLE
Remove support for Python 2

### DIFF
--- a/DrawBot.py
+++ b/DrawBot.py
@@ -5,8 +5,6 @@ import sys
 import os
 import random
 
-from fontTools.misc.py23 import PY3
-
 from vanilla.dialogs import message
 
 from drawBot.ui.drawBotController import DrawBotController
@@ -187,12 +185,8 @@ class DrawBotAppDelegate(AppKit.NSObject):
         DrawBotPackageController()
 
     def getUrl_withReplyEvent_(self, event, reply):
-        if PY3:
-            from urllib.parse import urlparse
-            from urllib.request import urlopen
-        else:
-            from urlparse import urlparse
-            from urllib2 import urlopen
+        from urllib.parse import urlparse
+        from urllib.request import urlopen
         code = stringToInt(b"----")
         url = event.paramDescriptorForKeyword_(code)
         urlString = url.stringValue()

--- a/drawBot/__init__.py
+++ b/drawBot/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from .drawBotDrawingTools import _drawBotDrawingTool
 
 _drawBotDrawingTool._addToNamespace(globals())

--- a/drawBot/context/__init__.py
+++ b/drawBot/context/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from .pdfContext import PDFContext
 from .imageContext import PNGContext, JPEGContext, TIFFContext, BMPContext
 from .gifContext import GIFContext

--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -8,7 +8,7 @@ import math
 import os
 
 from fontTools.pens.basePen import BasePen
-from fontTools.misc.py23 import basestring, PY2, unichr
+from fontTools.misc.py23 import basestring, unichr
 
 from drawBot.misc import DrawBotError, cmyk2rgb, warnings, transformationAtCenter
 
@@ -993,11 +993,6 @@ class FormattedString(object):
 
         Text can also be added with `formattedString += "hello"`. It will append the text with the current settings of the formatted string.
         """
-        if PY2 and isinstance(txt, basestring):
-            try:
-                txt = txt.decode("utf-8")
-            except UnicodeEncodeError:
-                pass
         attributes = self._validateAttributes(kwargs, addDefaults=False)
         for key, value in attributes.items():
             self._setAttribute(key, value)

--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -8,7 +8,6 @@ import math
 import os
 
 from fontTools.pens.basePen import BasePen
-from fontTools.misc.py23 import basestring, unichr
 
 from drawBot.misc import DrawBotError, cmyk2rgb, warnings, transformationAtCenter
 
@@ -265,7 +264,7 @@ class BezierPath(BasePen):
 
         Optionally `txt` can be a `FormattedString`.
         """
-        if not isinstance(txt, (basestring, FormattedString)):
+        if not isinstance(txt, (str, FormattedString)):
             raise TypeError("expected 'str' or 'FormattedString', got '%s'" % type(txt).__name__)
         if align and align not in BaseContext._textAlignMap.keys():
             raise DrawBotError("align must be %s" % (", ".join(BaseContext._textAlignMap.keys())))
@@ -307,7 +306,7 @@ class BezierPath(BasePen):
         Optionally `txt` can be a `FormattedString`.
         Optionally `box` can be a `BezierPath`.
         """
-        if not isinstance(txt, (basestring, FormattedString)):
+        if not isinstance(txt, (str, FormattedString)):
             raise TypeError("expected 'str' or 'FormattedString', got '%s'" % type(txt).__name__)
         if align and align not in BaseContext._textAlignMap.keys():
             raise DrawBotError("align must be %s" % (", ".join(BaseContext._textAlignMap.keys())))
@@ -1001,7 +1000,7 @@ class FormattedString(object):
         if isinstance(txt, FormattedString):
             self._attributedString.appendAttributedString_(txt.getNSObject())
             return
-        elif not isinstance(txt, (basestring, FormattedString)):
+        elif not isinstance(txt, (str, FormattedString)):
             raise TypeError("expected 'str' or 'FormattedString', got '%s'" % type(txt).__name__)
         attributes = {}
         if self._font:
@@ -1140,7 +1139,7 @@ class FormattedString(object):
         if isinstance(txt, self.__class__):
             new.getNSObject().appendAttributedString_(txt.getNSObject())
         else:
-            if not isinstance(txt, basestring):
+            if not isinstance(txt, str):
                 raise TypeError("FormattedString requires a str or unicode, got '%s'" % type(txt))
             new.append(txt)
         return new
@@ -1744,7 +1743,7 @@ class FormattedString(object):
             text(t, (100, 100))
         """
         # use a non breaking space as replacement character
-        baseString = unichr(0xFFFD)
+        baseString = chr(0xFFFD)
         font = None
         if self._font:
             font = AppKit.NSFont.fontWithName_size_(self._font, self._fontSize)
@@ -2239,7 +2238,7 @@ class BaseContext(object):
             while hyphenIndex != AppKit.NSNotFound:
                 hyphenIndex = attrString.lineBreakByHyphenatingBeforeIndex_withinRange_(hyphenIndex, wordRange)
                 if hyphenIndex != AppKit.NSNotFound:
-                    mutString.insertString_atIndex_(unichr(self._softHypen), hyphenIndex)
+                    mutString.insertString_atIndex_(chr(self._softHypen), hyphenIndex)
 
         # get the lines
         lines = self._getTypesetterLinesWithPath(attrString, path)
@@ -2258,7 +2257,7 @@ class BaseContext(object):
             # get the string
             subStringText = subString.string()
             # check if the line ends with a softhypen
-            if len(subStringText) and subStringText[-1] == unichr(self._softHypen):
+            if len(subStringText) and subStringText[-1] == chr(self._softHypen):
                 # here we go
                 # get the justified line and get the max line width
                 maxLineWidth, a, d, l = CoreText.CTLineGetTypographicBounds(justifiedLines[i], None, None, None)
@@ -2284,19 +2283,19 @@ class BaseContext(object):
                     # get the width
                     stringWidth = breakString.size().width
                     # add hyphen width if required
-                    if breakString.string()[-1] == unichr(self._softHypen):
+                    if breakString.string()[-1] == chr(self._softHypen):
                         stringWidth += hyphenWidth
                     # found a break
                     if stringWidth <= maxLineWidth:
                         breakFound = True
                         break
 
-                if breakFound and len(breakString.string()) > 2 and breakString.string()[-1] == unichr(self._softHypen):
+                if breakFound and len(breakString.string()) > 2 and breakString.string()[-1] == chr(self._softHypen):
                     # if the break line ends with a soft hyphen
                     # add a hyphen
                     attrString.replaceCharactersInRange_withString_((rng.location + lineBreak, 0), "-")
                 # remove all soft hyphens for the range of that line
-                mutString.replaceOccurrencesOfString_withString_options_range_(unichr(self._softHypen), "", AppKit.NSLiteralSearch, rng)
+                mutString.replaceOccurrencesOfString_withString_options_range_(chr(self._softHypen), "", AppKit.NSLiteralSearch, rng)
                 # reset the lines, from the adjusted attribute string
                 lines = self._getTypesetterLinesWithPath(attrString, path)
                 # reset the justifed lines form the adjusted attributed string
@@ -2304,7 +2303,7 @@ class BaseContext(object):
             # next line
             i += 1
         # remove all soft hyphen
-        mutString.replaceOccurrencesOfString_withString_options_range_(unichr(self._softHypen), "", AppKit.NSLiteralSearch, (0, mutString.length()))
+        mutString.replaceOccurrencesOfString_withString_options_range_(chr(self._softHypen), "", AppKit.NSLiteralSearch, (0, mutString.length()))
         # done!
         return attrString
 

--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import AppKit
 import CoreText
 import Quartz

--- a/drawBot/context/drawBotContext.py
+++ b/drawBot/context/drawBotContext.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import Quartz
 
 from .pdfContext import PDFContext

--- a/drawBot/context/dummyContext.py
+++ b/drawBot/context/dummyContext.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 from .baseContext import BaseContext
 
 

--- a/drawBot/context/gifContext.py
+++ b/drawBot/context/gifContext.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import Quartz
 
 import tempfile

--- a/drawBot/context/imageContext.py
+++ b/drawBot/context/imageContext.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division
-
 import AppKit
 import Quartz
 

--- a/drawBot/context/movContext.py
+++ b/drawBot/context/movContext.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import AppKit
 import QTKit
 import Quartz

--- a/drawBot/context/mp4Context.py
+++ b/drawBot/context/mp4Context.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import os
 import tempfile
 import shutil

--- a/drawBot/context/pdfContext.py
+++ b/drawBot/context/pdfContext.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import platform
 from distutils.version import StrictVersion
 import AppKit

--- a/drawBot/context/printContext.py
+++ b/drawBot/context/printContext.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 import AppKit
 from fontTools.pens.basePen import AbstractPen
 

--- a/drawBot/context/svgContext.py
+++ b/drawBot/context/svgContext.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-from fontTools.misc.py23 import round
 import AppKit
 import CoreText
 

--- a/drawBot/context/svgContext.py
+++ b/drawBot/context/svgContext.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import AppKit
 import CoreText
 

--- a/drawBot/context/tools/gifTools.py
+++ b/drawBot/context/tools/gifTools.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import AppKit
 import shutil
 import os

--- a/drawBot/context/tools/imageObject.py
+++ b/drawBot/context/tools/imageObject.py
@@ -5,7 +5,6 @@ from math import radians
 import os
 
 from drawBot.misc import DrawBotError, optimizePath
-from fontTools.misc.py23 import basestring
 from drawBot.context.imageContext import _makeBitmapImageRep
 
 
@@ -59,7 +58,7 @@ class ImageObject(object):
         """
         if isinstance(path, AppKit.NSImage):
             im = path
-        elif isinstance(path, basestring):
+        elif isinstance(path, str):
             path = optimizePath(path)
             if path.startswith("http"):
                 url = AppKit.NSURL.URLWithString_(path)

--- a/drawBot/context/tools/imageObject.py
+++ b/drawBot/context/tools/imageObject.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import AppKit
 from math import radians
 import os

--- a/drawBot/context/tools/mp4Tools.py
+++ b/drawBot/context/tools/mp4Tools.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import os
 
 from drawBot.misc import executeExternalProcess, getExternalToolPath

--- a/drawBot/context/tools/traceImage.py
+++ b/drawBot/context/tools/traceImage.py
@@ -1,5 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
 import AppKit
 import tempfile
 from xml.dom import minidom

--- a/drawBot/drawBotDrawingTools.py
+++ b/drawBot/drawBotDrawingTools.py
@@ -18,8 +18,6 @@ from .context.tools import openType
 
 from .misc import DrawBotError, warnings, VariableController, optimizePath, isPDF, isEPS, isGIF, transformationAtCenter, clearMemoizeCache
 
-from fontTools.misc.py23 import basestring
-
 
 def _getmodulecontents(module, names=None):
     d = {}
@@ -1611,7 +1609,7 @@ class DrawBotDrawingTool(object):
             text("hallo", (200, 600))
             text("I'm Times", (100, 300))
         """
-        if not isinstance(txt, (basestring, FormattedString)):
+        if not isinstance(txt, (str, FormattedString)):
             raise TypeError("expected 'str' or 'FormattedString', got '%s'" % type(txt).__name__)
         if y is None:
             x, y = x
@@ -1653,7 +1651,7 @@ class DrawBotDrawingTool(object):
         """
         if isinstance(txt, self._formattedStringClass):
             txt = txt.copy()
-        elif not isinstance(txt, (basestring, FormattedString)):
+        elif not isinstance(txt, (str, FormattedString)):
             raise TypeError("expected 'str' or 'FormattedString', got '%s'" % type(txt).__name__)
         if align is None:
             align = "left"
@@ -1789,7 +1787,7 @@ class DrawBotDrawingTool(object):
             # draw some text in the path
             textBox("abcdefghijklmnopqrstuvwxyz"*30000, path)
         """
-        if not isinstance(txt, (basestring, FormattedString)):
+        if not isinstance(txt, (str, FormattedString)):
             raise TypeError("expected 'str' or 'FormattedString', got '%s'" % type(txt).__name__)
         if align is None:
             align = "left"
@@ -1810,7 +1808,7 @@ class DrawBotDrawingTool(object):
         Optionally an alignment can be set.
         Possible `align` values are: `"left"`, `"center"`, `"right"` and `"justified"`.
         """
-        if not isinstance(txt, (basestring, FormattedString)):
+        if not isinstance(txt, (str, FormattedString)):
             raise TypeError("expected 'str' or 'FormattedString', got '%s'" % type(txt).__name__)
         path, (x, y) = self._dummyContext._getPathForFrameSetter(box)
         attrString = self._dummyContext.attributedString(txt)
@@ -1879,7 +1877,7 @@ class DrawBotDrawingTool(object):
         """
         if isinstance(path, self._imageClass):
             path = path._nsImage()
-        if isinstance(path, basestring):
+        if isinstance(path, str):
             path = optimizePath(path)
         self._requiresNewFirstPage = True
         self._addInstruction("image", path, position, alpha, pageNumber)
@@ -1902,7 +1900,7 @@ class DrawBotDrawingTool(object):
             # its an NSImage
             rep = path
         else:
-            if isinstance(path, basestring):
+            if isinstance(path, str):
                 path = optimizePath(path)
             if path.startswith("http"):
                 url = AppKit.NSURL.URLWithString_(path)
@@ -1972,7 +1970,7 @@ class DrawBotDrawingTool(object):
                         text("W", (x, y))
         """
         x, y = xy
-        if isinstance(path, basestring):
+        if isinstance(path, str):
             path = optimizePath(path)
         bitmap = self._cachedPixelColorBitmaps.get(path)
         if bitmap is None:
@@ -2010,7 +2008,7 @@ class DrawBotDrawingTool(object):
             # get the bitmap representation
             rep = reps[0]
         else:
-            if isinstance(path, basestring):
+            if isinstance(path, str):
                 path = optimizePath(path)
             if path.startswith("http"):
                 url = AppKit.NSURL.URLWithString_(path)
@@ -2130,7 +2128,7 @@ class DrawBotDrawingTool(object):
         Optionally a `width` constrain or `height` constrain can be provided
         to calculate the lenght or width of text with the given constrain.
         """
-        if not isinstance(txt, (basestring, FormattedString)):
+        if not isinstance(txt, (str, FormattedString)):
             raise TypeError("expected 'str' or 'FormattedString', got '%s'" % type(txt).__name__)
         if width is not None and height is not None:
             raise DrawBotError("Calculating textSize can only have one constrain, either width or height must be None")

--- a/drawBot/drawBotDrawingTools.py
+++ b/drawBot/drawBotDrawingTools.py
@@ -18,7 +18,7 @@ from .context.tools import openType
 
 from .misc import DrawBotError, warnings, VariableController, optimizePath, isPDF, isEPS, isGIF, transformationAtCenter, clearMemoizeCache
 
-from fontTools.misc.py23 import basestring, PY2
+from fontTools.misc.py23 import basestring
 
 
 def _getmodulecontents(module, names=None):
@@ -1611,11 +1611,6 @@ class DrawBotDrawingTool(object):
             text("hallo", (200, 600))
             text("I'm Times", (100, 300))
         """
-        if PY2 and isinstance(txt, basestring):
-            try:
-                txt = txt.decode("utf-8")
-            except UnicodeEncodeError:
-                pass
         if not isinstance(txt, (basestring, FormattedString)):
             raise TypeError("expected 'str' or 'FormattedString', got '%s'" % type(txt).__name__)
         if y is None:
@@ -1656,11 +1651,6 @@ class DrawBotDrawingTool(object):
         Optionally `txt` can be a `FormattedString`.
         Optionally `box` can be a `BezierPath`.
         """
-        if PY2 and isinstance(txt, basestring):
-            try:
-                txt = txt.decode("utf-8")
-            except UnicodeEncodeError:
-                pass
         if isinstance(txt, self._formattedStringClass):
             txt = txt.copy()
         elif not isinstance(txt, (basestring, FormattedString)):
@@ -1799,11 +1789,6 @@ class DrawBotDrawingTool(object):
             # draw some text in the path
             textBox("abcdefghijklmnopqrstuvwxyz"*30000, path)
         """
-        if PY2 and isinstance(txt, basestring):
-            try:
-                txt = txt.decode("utf-8")
-            except UnicodeEncodeError:
-                pass
         if not isinstance(txt, (basestring, FormattedString)):
             raise TypeError("expected 'str' or 'FormattedString', got '%s'" % type(txt).__name__)
         if align is None:
@@ -1825,11 +1810,6 @@ class DrawBotDrawingTool(object):
         Optionally an alignment can be set.
         Possible `align` values are: `"left"`, `"center"`, `"right"` and `"justified"`.
         """
-        if PY2 and isinstance(txt, basestring):
-            try:
-                txt = txt.decode("utf-8")
-            except UnicodeEncodeError:
-                pass
         if not isinstance(txt, (basestring, FormattedString)):
             raise TypeError("expected 'str' or 'FormattedString', got '%s'" % type(txt).__name__)
         path, (x, y) = self._dummyContext._getPathForFrameSetter(box)
@@ -2150,11 +2130,6 @@ class DrawBotDrawingTool(object):
         Optionally a `width` constrain or `height` constrain can be provided
         to calculate the lenght or width of text with the given constrain.
         """
-        if PY2 and isinstance(txt, basestring):
-            try:
-                txt = txt.decode("utf-8")
-            except UnicodeEncodeError:
-                pass
         if not isinstance(txt, (basestring, FormattedString)):
             raise TypeError("expected 'str' or 'FormattedString', got '%s'" % type(txt).__name__)
         if width is not None and height is not None:

--- a/drawBot/drawBotDrawingTools.py
+++ b/drawBot/drawBotDrawingTools.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import AppKit
 import CoreText
 import Quartz

--- a/drawBot/drawBotPageDrawingTools.py
+++ b/drawBot/drawBotPageDrawingTools.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from .drawBotDrawingTools import _drawBotDrawingTool, DrawBotDrawingTool
 
 

--- a/drawBot/scriptTools.py
+++ b/drawBot/scriptTools.py
@@ -1,7 +1,3 @@
-from __future__ import division, absolute_import, print_function
-
-# -*- coding: UTF-8 -*-
-import __future__
 import AppKit
 import time
 import os
@@ -177,6 +173,7 @@ def ScriptRunner(text=None, path=None, stdout=None, stderr=None, namespace=None,
     source = text.replace('\r\n', '\n').replace('\r', '\n')
     compileFlags = 0
     if getDefault("DrawBotUseFutureDivision", True):
+        import __future__
         compileFlags |= __future__.CO_FUTURE_DIVISION
 
     try:

--- a/drawBot/scriptTools.py
+++ b/drawBot/scriptTools.py
@@ -16,7 +16,6 @@ from ctypes.util import find_library
 import threading
 from distutils.version import StrictVersion
 import platform
-from fontTools.misc.py23 import PY2, PY3
 from drawBot.misc import getDefault
 from objc import super
 
@@ -58,11 +57,6 @@ class StdOutput(object):
         # ignore all warnings
         # we dont want warnings while pusing text to the textview
         warnings.filterwarnings("ignore")
-        if PY2 and isinstance(data, str):
-            try:
-                data = unicode(data, "utf-8", "replace")
-            except UnicodeDecodeError:
-                data = "XXX " + repr(data)
         if self.outputView is not None:
             # Better not get SIGINT/KeyboardInterrupt exceptions while we're updating the output view
             with cancelLock:
@@ -89,19 +83,12 @@ class StdOutput(object):
 
 def _addLocalSysPaths():
     version = "%s.%s" % (sys.version_info.major, sys.version_info.minor)
-    if PY3:
-        paths = [
-            # add local stdlib and site-packages; TODO: this needs editing once we embed the full stdlib
-            '/Library/Frameworks/Python.framework/Versions/%s/lib/python%s' % (version, version),
-            '/Library/Frameworks/Python.framework/Versions/%s/lib/python%s/lib-dynload' % (version, version),
-            '/Library/Frameworks/Python.framework/Versions/%s/lib/python%s/site-packages' % (version, version),
-        ]
-    else:
-        paths = [
-            '/System/Library/Frameworks/Python.framework/Versions/%s/lib/python%s' % (version, version),
-            '/System/Library/Frameworks/Python.framework/Versions/%s/lib/python%s/lib-dynload' % (version, version),
-            '/System/Library/Frameworks/Python.framework/Versions/%s/lib/python%s/site-packages' % (version, version),
-        ]
+    paths = [
+        # add local stdlib and site-packages; TODO: this needs editing once we embed the full stdlib
+        '/Library/Frameworks/Python.framework/Versions/%s/lib/python%s' % (version, version),
+        '/Library/Frameworks/Python.framework/Versions/%s/lib/python%s/lib-dynload' % (version, version),
+        '/Library/Frameworks/Python.framework/Versions/%s/lib/python%s/site-packages' % (version, version),
+    ]
 
     paths.append('/Library/Python/%s/site-packages' % version)
 
@@ -156,8 +143,6 @@ def ScriptRunner(text=None, path=None, stdout=None, stderr=None, namespace=None,
             time.sleep(0.25)  # check at most 4 times per second
 
     if path:
-        if PY2 and isinstance(path, unicode):
-            path = path.encode("utf-8")
         curDir, fileName = os.path.split(path)
     else:
         curDir = os.getenv("HOME")
@@ -190,10 +175,6 @@ def ScriptRunner(text=None, path=None, stdout=None, stderr=None, namespace=None,
         with open(path, 'rb') as f:
             text = f.read().decode("utf-8")
     source = text.replace('\r\n', '\n').replace('\r', '\n')
-    if PY2 and hasEncodingDeclaration(source) and isinstance(source, unicode):
-        # Python 2 compile() complains when an encoding declaration is found in a unicode string.
-        # As a workaround, we'll just encode it back as a utf-8 string and all is good.
-        source = source.encode("utf-8")
     compileFlags = 0
     if getDefault("DrawBotUseFutureDivision", True):
         compileFlags |= __future__.CO_FUTURE_DIVISION

--- a/drawBot/scriptTools.py
+++ b/drawBot/scriptTools.py
@@ -172,9 +172,6 @@ def ScriptRunner(text=None, path=None, stdout=None, stderr=None, namespace=None,
             text = f.read().decode("utf-8")
     source = text.replace('\r\n', '\n').replace('\r', '\n')
     compileFlags = 0
-    if getDefault("DrawBotUseFutureDivision", True):
-        import __future__
-        compileFlags |= __future__.CO_FUTURE_DIVISION
 
     try:
         try:

--- a/drawBot/ui/codeEditor.py
+++ b/drawBot/ui/codeEditor.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import AppKit
 from objc import super
 

--- a/drawBot/ui/codeEditor.py
+++ b/drawBot/ui/codeEditor.py
@@ -20,7 +20,6 @@ except Exception:
 
 from vanilla import *
 from vanilla.py23 import python_method
-from fontTools.misc.py23 import PY3, unichr
 
 from .lineNumberRulerView import LineNumberNSRulerView
 from drawBot.misc import getDefault, getFontDefault, getColorDefault, DrawBotError, nsStringLength
@@ -140,7 +139,7 @@ class _JumpToLineSheet(object):
 
         self.w.cancelButton = Button((-170, -30, -80, 20), "Cancel", callback=self.cancelCallback, sizeStyle="small")
         self.w.cancelButton.bind(".", ["command"])
-        self.w.cancelButton.bind(unichr(27), [])
+        self.w.cancelButton.bind(chr(27), [])
 
         self.w.okButton = Button((-70, -30, -10, 20), "OK", callback=self.okCallback, sizeStyle="small")
         self.w.setDefaultButton(self.w.okButton)
@@ -305,26 +304,20 @@ languagesIDEBehavior = {
         "comment": "#",
         "keywords": kwlist,
         "wordCompletions": _pythonWordCompletions,
-        "dropPathFormatting": 'u"%s"',
+        "dropPathFormatting": '%r',
         "dropPathsFormatting": '[%s]',
         "dropPathsSeperator": ", "
     },
 }
-if PY3:
-    languagesIDEBehavior["Python"]["dropPathFormatting"] = '%r'
 
 downArrowSelectionDirection = 0
 upArrowSelectionDirection = 1
 
-if PY3:
-    def _floatRepr(f):
-        """In Python 3, we may get float representations that are too precise,
-        like 0.199999999999999. That is not nice for our interactive number
-        editing."""
-        return str(round(f, 8))
-else:
-    def _floatRepr(f):
-        return f
+def _floatRepr(f):
+    """In Python 3, we may get float representations that are too precise,
+    like 0.199999999999999. That is not nice for our interactive number
+    editing."""
+    return str(round(f, 8))
 
 
 class CodeNSTextView(AppKit.NSTextView):

--- a/drawBot/ui/debug.py
+++ b/drawBot/ui/debug.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from Foundation import NSLog
 from AppKit import NSPanel
 

--- a/drawBot/ui/drawBotController.py
+++ b/drawBot/ui/drawBotController.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import AppKit
 from vanilla import *
 from defconAppKit.windows.baseWindow import BaseWindowController

--- a/drawBot/ui/preferencesController.py
+++ b/drawBot/ui/preferencesController.py
@@ -339,9 +339,9 @@ class SyntaxColors(Group):
 class PreferencesController(BaseWindowController):
 
     def __init__(self):
-        self.w = Window((500, 460), miniaturizable=False, minSize=(500, 430))
+        self.w = Window((500, 430), miniaturizable=False, minSize=(500, 430))
 
-        y = -220
+        y = -190
         self.w.syntaxColors = SyntaxColors((0, 0, -0, y))
 
         self.w.hl1 = HorizontalLine((10, y, -10, 1))
@@ -349,8 +349,6 @@ class PreferencesController(BaseWindowController):
         self.w.clearOutPut = CheckBox((10, y, -10, 22), "Clear text output before running script", callback=self.setToDefaults)
         y += 30
         self.w.liveOutPut = CheckBox((10, y, -10, 22), "Live update output", callback=self.setToDefaults)
-        y += 30
-        self.w.useFutureDivision = CheckBox((10, y, -10, 22), "Use Future Division (relaxed float division)", callback=self.setToDefaults)
         y += 30
         self.w.shouldOpenUntitledFile = CheckBox((10, y, -10, 22), "Should Open Untitled File", callback=self.setToDefaults)
         y += 30
@@ -367,7 +365,6 @@ class PreferencesController(BaseWindowController):
     def getFromDefaults(self):
         self.w.clearOutPut.set(getDefault("DrawBotClearOutput", True))
         self.w.liveOutPut.set(getDefault("DrawButLiveUpdateStdoutStderr", False))
-        self.w.useFutureDivision.set(getDefault("DrawBotUseFutureDivision", True))
         self.w.animateIcon.set(getDefault("DrawBotAnimateIcon", True))
         self.w.checkForUpdates.set(getDefault("DrawBotCheckForUpdatesAtStartup", True))
         self.w.shouldOpenUntitledFile.set(getDefault("shouldOpenUntitledFile", True))
@@ -377,7 +374,6 @@ class PreferencesController(BaseWindowController):
     def setToDefaults(self, sender=None):
         setDefault("DrawBotClearOutput", self.w.clearOutPut.get())
         setDefault("DrawButLiveUpdateStdoutStderr", self.w.liveOutPut.get())
-        setDefault("DrawBotUseFutureDivision", self.w.useFutureDivision.get())
         setDefault("DrawBotAnimateIcon", self.w.animateIcon.get())
         setDefault("DrawBotCheckForUpdatesAtStartup", self.w.checkForUpdates.get())
         setDefault("shouldOpenUntitledFile", self.w.shouldOpenUntitledFile.get())

--- a/drawBot/ui/preferencesController.py
+++ b/drawBot/ui/preferencesController.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from Foundation import NSObject, NSMutableAttributedString, NSInsetRect
 from AppKit import NSApp, NSColorWell, NSActionCell, NSNotificationCenter, NSFontManager, \
     NSCalibratedRGBColorSpace, NSTableViewFirstColumnOnlyAutoresizingStyle, \

--- a/drawBot/updater.py
+++ b/drawBot/updater.py
@@ -18,8 +18,6 @@ from defconAppKit.windows.progressWindow import ProgressWindow
 from drawBot import __version__
 from .misc import DrawBotError, getDefault
 
-from fontTools.misc.py23 import unichr, PY2
-
 
 _versionRE = re.compile(r'__version__\s*=\s*\"([^\"]+)\"')
 
@@ -55,10 +53,7 @@ def downloadCurrentVersion():
     """
     Download the current version (dmg) and mount it
     """
-    if PY2:
-        path = "https://static.typemytype.com/drawBot/DrawBotPy2.dmg"
-    else:
-        path = "https://static.typemytype.com/drawBot/DrawBot.dmg"
+    path = "https://static.typemytype.com/drawBot/DrawBot.dmg"
     try:
         # download and mount
         cmds = ["hdiutil", "attach", "-plist", path]
@@ -106,7 +101,7 @@ class Updater(object):
 
         self.w.cancelButton = vanilla.Button((-270, -30, 60, 20), "Cancel", callback=self.cancelCallback, sizeStyle="small")
         self.w.cancelButton.bind(".", ["command"])
-        self.w.cancelButton.bind(unichr(27), [])
+        self.w.cancelButton.bind(chr(27), [])
 
         self.w.openInBrowser = vanilla.Button((-200, -30, 120, 20), "Show In Browser", callback=self.openInBrowserCallback, sizeStyle="small")
         self.w.okButton = vanilla.Button((-70, -30, 55, 20), "OK", callback=self.okCallback, sizeStyle="small")

--- a/drawBot/updater.py
+++ b/drawBot/updater.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 try:
     from urllib2 import urlopen
 except ImportError:

--- a/drawBot/updater.py
+++ b/drawBot/updater.py
@@ -1,7 +1,4 @@
-try:
-    from urllib2 import urlopen
-except ImportError:
-    from urllib.request import urlopen
+from urllib.request import urlopen
 import ssl
 import subprocess
 import plistlib

--- a/tests/data/scriptRunnerTest.py
+++ b/tests/data/scriptRunnerTest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 # test file used by testMisc.MiscTest.test_ScriptRunner_fromPath
 print(__file__)
 print(__name__)

--- a/tests/drawBotScripts/fontVariations.py
+++ b/tests/drawBotScripts/fontVariations.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from drawBot import *
 
 size(200, 200)

--- a/tests/drawBotScripts/fontVariations2.py
+++ b/tests/drawBotScripts/fontVariations2.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from drawBot import *
 
 size(200, 200)

--- a/tests/drawBotScripts/imagePixelColor.py
+++ b/tests/drawBotScripts/imagePixelColor.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 # This is a test case derived from https://github.com/typemytype/drawbot/issues/171
 # It ensures that rgb values specified in fill() end up in image output without
 # being mangled by a color space (within 8-bit resulution).

--- a/tests/runAllTests.py
+++ b/tests/runAllTests.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, division, absolute_import
 import sys
 import os
 import unittest

--- a/tests/testExamples.py
+++ b/tests/testExamples.py
@@ -128,11 +128,9 @@ def mockRandInt(lo, hi):
 def _makeTestCase(exampleName, source, doSaveImage, allowFuzzyImageComparison):
 
     def test(self):
-        import __future__
         from drawBot.drawBotDrawingTools import _drawBotDrawingTool
 
-        compileFlags = __future__.CO_FUTURE_DIVISION
-        code = compile(source, "<%s>" % exampleName, "exec", flags=compileFlags, dont_inherit=True)
+        code = compile(source, "<%s>" % exampleName, "exec")
 
         namespace = {}
         _drawBotDrawingTool._addToNamespace(namespace)

--- a/tests/testExamples.py
+++ b/tests/testExamples.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-from fontTools.misc.py23 import *
 import sys
 import os
 import unittest

--- a/tests/testExport.py
+++ b/tests/testExport.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-from fontTools.misc.py23 import *
 import sys
 import os
 import unittest

--- a/tests/testMisc.py
+++ b/tests/testMisc.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-from fontTools.misc.py23 import *
 import sys
 import os
 import unittest

--- a/tests/testMisc.py
+++ b/tests/testMisc.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
 from fontTools.misc.py23 import *
-from fontTools.misc.py23 import PY3
 import sys
 import os
 import unittest
@@ -114,34 +113,23 @@ class MiscTest(unittest.TestCase):
         self.assertEqual(out.lines(), ["hey!"])
 
     def test_ScriptRunner_io(self):
-        if PY3:
-            MyStringIO = io.StringIO
-        else:
-            class MyStringIO(io.StringIO):
-                def write(self, value):
-                    if not isinstance(value, unicode):
-                        value = value.decode("utf8")
-                    super(MyStringIO, self).write(value)
-        out = MyStringIO()
+        out = io.StringIO()
         ScriptRunner("print('hey!')", stdout=out, stderr=out)
         self.assertEqual(out.getvalue(), u'hey!\n')
-        out = MyStringIO()
+        out = io.StringIO()
         ScriptRunner("print(u'hey!')", stdout=out, stderr=out)
         self.assertEqual(out.getvalue(), u'hey!\n')
-        out = MyStringIO()
+        out = io.StringIO()
         ScriptRunner(u"print('hey!')", stdout=out, stderr=out)
         self.assertEqual(out.getvalue(), u'hey!\n')
-        out = MyStringIO()
+        out = io.StringIO()
         ScriptRunner(u"print(u'hey!')", stdout=out, stderr=out)
         self.assertEqual(out.getvalue(), u'hey!\n')
 
     def test_ScriptRunner_print_function(self):
         out = StdOutCollector()
         ScriptRunner("print 'hey!'", stdout=out, stderr=out)
-        if PY3:
-            self.assertEqual(out.lines()[-1], "SyntaxError: Missing parentheses in call to 'print'. Did you mean print('hey!')?")
-        else:
-            self.assertEqual(out.lines(), ["hey!"])
+        self.assertEqual(out.lines()[-1], "SyntaxError: Missing parentheses in call to 'print'. Did you mean print('hey!')?")
 
     def test_ScriptRunner_division(self):
         out = StdOutCollector()
@@ -156,10 +144,7 @@ class MiscTest(unittest.TestCase):
         try:
             out = StdOutCollector()
             ScriptRunner("print(1/2)", stdout=out, stderr=out)
-            if PY3:
-                self.assertEqual(out.lines(), ["0.5"])
-            else:
-                self.assertEqual(out.lines(), ["0"])
+            self.assertEqual(out.lines(), ["0.5"])
         finally:
             drawBot.scriptTools.getDefault = realGetDefault
 

--- a/tests/testScripts.py
+++ b/tests/testScripts.py
@@ -1,6 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
-from fontTools.misc.py23 import *
 import AppKit
 import unittest
 import os

--- a/tests/testScripts.py
+++ b/tests/testScripts.py
@@ -57,13 +57,11 @@ class DrawBotTest(unittest.TestCase):
 
     def executeScriptPath(self, path):
         # read content of py file and exec it
-        import __future__
         from drawBot.misc import warnings
 
         with open(path) as f:
             source = f.read()
-        compileFlags = __future__.CO_FUTURE_DIVISION
-        code = compile(source, path, "exec", flags=compileFlags, dont_inherit=True)
+        code = compile(source, path, "exec")
         namespace = {"__name__": "__main__", "__file__": path}
         warnings.resetWarnings()  # so we can test DB warnings
 

--- a/tests/testSupport.py
+++ b/tests/testSupport.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import sys
 import os
 import tempfile

--- a/tests/testSupport.py
+++ b/tests/testSupport.py
@@ -1,6 +1,5 @@
 from __future__ import print_function, division, absolute_import
 
-from fontTools.misc.py23 import PY3
 import sys
 import os
 import tempfile
@@ -9,7 +8,6 @@ import random
 import io
 from PIL import Image, ImageChops
 from drawBot.misc import warnings
-from fontTools.misc.py23 import PY2
 
 
 testRootDir = os.path.dirname(os.path.abspath(__file__))
@@ -47,8 +45,6 @@ class StdOutCollector(object):
         sys.stderr = self.err
 
     def write(self, txt):
-        if PY2 and not isinstance(txt, unicode):
-            txt = txt.decode("utf-8")
         self._stream.write(txt)
 
     def flush(self):
@@ -114,10 +110,7 @@ class TempFolder(TempFile):
 
 
 def randomSeed(a):
-    if PY3:
-        return random.seed(a, version=1)  # compatible with Python 2
-    else:
-        return random.seed(a)
+    return random.seed(a, version=1)  # compatible with Python 2
 
 
 def readData(path):


### PR DESCRIPTION
Mostly to get rid of usages of `fontTools.misc.py23.PY2` and `fontTools.misc.py23.PY3`, but went ahead and removed most usage of py23 altogether.

Todo:
- [x] `__future__` statements
- [x] `py23` usage in tests
- [x] `__future__` flag usage in code compilation
- [x] get rid of `__future__` division preference