### PR TITLE
expandStroke method for BezierPath object

### DIFF
--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -393,7 +393,7 @@ class BezierPath(BasePen):
         """
         return self._path
 
-    def _getCGPath(self, withBounds=False):
+    def _getCGPath(self):
         path = Quartz.CGPathCreateMutable()
         count = self._path.elementCount()
         for i in range(count):
@@ -411,14 +411,6 @@ class BezierPath(BasePen):
                 )
             elif instruction == AppKit.NSClosePathBezierPathElement:
                 Quartz.CGPathCloseSubpath(path)
-        # hacking to get a proper close path at the end of the path
-        if withBounds:
-            x, y, _, _ = self.bounds()
-            Quartz.CGPathMoveToPoint(path, None, x, y)
-            Quartz.CGPathAddLineToPoint(path, None, x, y)
-            Quartz.CGPathAddLineToPoint(path, None, x, y)
-            Quartz.CGPathAddLineToPoint(path, None, x, y)
-            Quartz.CGPathCloseSubpath(path)
         return path
 
     def _setCGPath(self, cgpath):

--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -646,6 +646,20 @@ class BezierPath(BasePen):
         return booleanOperations.getIntersections(contours)
 
     def strokePath(self, width, lineCap="round", lineJoin="round", miterLimit=10):
+        """
+        Strokes the path with the given width.
+
+        Optionally these options can be set:
+
+        * `lineCap`: Possible values are `"butt"`, `"square"` or `"round"`
+        * `lineJoin`: Possible values are `"bevel"`, `"miter"` or `"round"`
+        * `mitterLimit`: The miter limit to use for `"miter"` lineJoin option
+        """
+        if lineJoin not in _LINEJOINSTYLESMAP:
+            raise DrawBotError("lineJoin must be 'bevel', 'miter' or 'round'")
+        if lineCap not in _LINECAPSTYLESMAP:
+            raise DrawBotError("lineCap must be 'butt', 'square' or 'round'")
+
         strokedCGPath = Quartz.CGPathCreateCopyByStrokingPath(self._getCGPath(), None, width, _LINECAPSTYLESMAP[lineCap], _LINEJOINSTYLESMAP[lineJoin], miterLimit)
         self._setCGpath(strokedCGPath)
 
@@ -2211,7 +2225,7 @@ class BaseContext(object):
     def lineCap(self, cap):
         if cap is None:
             self._state.lineCap = None
-        if cap not in self._LINECAPSTYLESMAP:
+        if cap not in _LINECAPSTYLESMAP:
             raise DrawBotError("lineCap() argument must be 'butt', 'square' or 'round'")
         self._state.lineCap = _LINECAPSTYLESMAP[cap]
 

--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -2398,7 +2398,7 @@ class BaseContext(object):
 
     def _getPathForFrameSetter(self, box):
         if isinstance(box, self._bezierPathClass):
-            path = box._getCGPath(withBounds=True)
+            path = box._getCGPath()
             (x, y), (w, h) = CoreText.CGPathGetPathBoundingBox(path)
         else:
             x, y, w, h = box

--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -639,14 +639,13 @@ class BezierPath(BasePen):
 
     def expandStroke(self, width, lineCap="round", lineJoin="round", miterLimit=10):
         """
-        Returns a new bezier path with an expanded stroke around the bezier
-        path with a given width.
+        Returns a new bezier path with an expanded stroke around the original path,
+        with a given `width`. Note: the new path will not contain the original path.
 
-        Optionally these options can be set:
-
+        The following optional arguments are available with respect to line caps and joins:
         * `lineCap`: Possible values are `"butt"`, `"square"` or `"round"`
         * `lineJoin`: Possible values are `"bevel"`, `"miter"` or `"round"`
-        * `mitterLimit`: The miter limit to use for `"miter"` lineJoin option
+        * `miterLimit`: The miter limit to use for `"miter"` lineJoin option
         """
         if lineJoin not in _LINEJOINSTYLESMAP:
             raise DrawBotError("lineJoin must be 'bevel', 'miter' or 'round'")


### PR DESCRIPTION
~~The method strokes the path itself, so it does not return anything~~. I changed the _getCGPath so it doesn't add the bounds when it's not needed and moved the _LINEJOINSTYLESMAP and _LINECAPSTYLESMAP outside the BaseContext. Not sure if it suits the clean look of the code.