### PR TITLE
Changes text() argument name to "position" instead of "x"

### DIFF
--- a/drawBot/drawBotDrawingTools.py
+++ b/drawBot/drawBotDrawingTools.py
@@ -1577,7 +1577,7 @@ class DrawBotDrawingTool(object):
 
     # drawing text
 
-    def text(self, txt, x, y=None, align=None):
+    def text(self, txt, position, y=None, align=None):
         """
         Draw a text at a provided position.
 
@@ -1599,8 +1599,9 @@ class DrawBotDrawingTool(object):
         if not isinstance(txt, (str, FormattedString)):
             raise TypeError("expected 'str' or 'FormattedString', got '%s'" % type(txt).__name__)
         if y is None:
-            x, y = x
+            x, y = position
         else:
+            x = position
             warnings.warn("position must a tuple: text('%s', (%s, %s))" % (txt, x, y))
         if align is None:
             align = "left"


### PR DESCRIPTION
Improves the error message when an argument is missing in the `text()` function. This came up during a class I was teaching, without any arguments this is the error message —

`TypeError: text() missing 2 required positional arguments: 'txt' and 'x'`

...which isn't clear, since `x` should technically be a tuple of `(x, y)`. I understand that it's named this way for legacy reasons (which is why there's an optional argument for `y`) but it would be more clear to rename the argument as `position` —

`TypeError: text() missing 2 required positional arguments: 'txt' and 'position'`

This is the same argument name that's used in `image()` when it also needs a tuple for position.