### PR TITLE
Check that a path has elements before optimizing

### DIFF
--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -449,21 +449,21 @@ class BezierPath(BasePen):
 
     def optimizePath(self):
         count = self._path.elementCount()
-        if count > 0:
-            if self._path.elementAtIndex_(count - 1) == AppKit.NSMoveToBezierPathElement:
-                optimizedPath = AppKit.NSBezierPath.alloc().init()
-                for i in range(count - 1):
-                    instruction, points = self._path.elementAtIndex_associatedPoints_(i)
-                    if instruction == AppKit.NSMoveToBezierPathElement:
-                        optimizedPath.moveToPoint_(*points)
-                    elif instruction == AppKit.NSLineToBezierPathElement:
-                        optimizedPath.lineToPoint_(*points)
-                    elif instruction == AppKit.NSCurveToBezierPathElement:
-                        p1, p2, p3 = points
-                        optimizedPath.curveToPoint_controlPoint1_controlPoint2_(p3, p1, p2)
-                    elif instruction == AppKit.NSClosePathBezierPathElement:
-                        optimizedPath.closePath()
-                self._path = optimizedPath
+        if not count or self._path.elementAtIndex_(count - 1) != AppKit.NSMoveToBezierPathElement:
+            return
+        optimizedPath = AppKit.NSBezierPath.alloc().init()
+        for i in range(count - 1):
+            instruction, points = self._path.elementAtIndex_associatedPoints_(i)
+            if instruction == AppKit.NSMoveToBezierPathElement:
+                optimizedPath.moveToPoint_(*points)
+            elif instruction == AppKit.NSLineToBezierPathElement:
+                optimizedPath.lineToPoint_(*points)
+            elif instruction == AppKit.NSCurveToBezierPathElement:
+                p1, p2, p3 = points
+                optimizedPath.curveToPoint_controlPoint1_controlPoint2_(p3, p1, p2)
+            elif instruction == AppKit.NSClosePathBezierPathElement:
+                optimizedPath.closePath()
+        self._path = optimizedPath
 
     def copy(self):
         """

--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -449,20 +449,21 @@ class BezierPath(BasePen):
 
     def optimizePath(self):
         count = self._path.elementCount()
-        if self._path.elementAtIndex_(count - 1) == AppKit.NSMoveToBezierPathElement:
-            optimizedPath = AppKit.NSBezierPath.alloc().init()
-            for i in range(count - 1):
-                instruction, points = self._path.elementAtIndex_associatedPoints_(i)
-                if instruction == AppKit.NSMoveToBezierPathElement:
-                    optimizedPath.moveToPoint_(*points)
-                elif instruction == AppKit.NSLineToBezierPathElement:
-                    optimizedPath.lineToPoint_(*points)
-                elif instruction == AppKit.NSCurveToBezierPathElement:
-                    p1, p2, p3 = points
-                    optimizedPath.curveToPoint_controlPoint1_controlPoint2_(p3, p1, p2)
-                elif instruction == AppKit.NSClosePathBezierPathElement:
-                    optimizedPath.closePath()
-            self._path = optimizedPath
+        if count > 0:
+            if self._path.elementAtIndex_(count - 1) == AppKit.NSMoveToBezierPathElement:
+                optimizedPath = AppKit.NSBezierPath.alloc().init()
+                for i in range(count - 1):
+                    instruction, points = self._path.elementAtIndex_associatedPoints_(i)
+                    if instruction == AppKit.NSMoveToBezierPathElement:
+                        optimizedPath.moveToPoint_(*points)
+                    elif instruction == AppKit.NSLineToBezierPathElement:
+                        optimizedPath.lineToPoint_(*points)
+                    elif instruction == AppKit.NSCurveToBezierPathElement:
+                        p1, p2, p3 = points
+                        optimizedPath.curveToPoint_controlPoint1_controlPoint2_(p3, p1, p2)
+                    elif instruction == AppKit.NSClosePathBezierPathElement:
+                        optimizedPath.closePath()
+                self._path = optimizedPath
 
     def copy(self):
         """


### PR DESCRIPTION
A situation can arise where a BezierPath has no elements, resulting in a traceback in the optimizePath function:

```python
import drawBot as db
db.newDrawing()
path = db.BezierPath()
path.textBox("", (0, 0, 100, 100))
db.drawPath(path)
```

```
Traceback (most recent call last):
  File "<untitled>", line 4, in <module>
  File "/Users/clymer/Documents/Code/Git repos/GitHub/typemytype/drawbot/drawBot/context/baseContext.py", line 361, in textBox
  File "/Users/clymer/Documents/Code/Git repos/GitHub/typemytype/drawbot/drawBot/context/baseContext.py", line 452, in optimizePath
IndexError: NSRangeException - elementAtIndex:associatedPoints:: index (-1) beyond bounds (0)
```

This PR optimizes the path only if the element count is greater than zero.