### PR TITLE
(hopefully) fix #377: bundle setuptools and packaging

### DIFF
--- a/setupApp.py
+++ b/setupApp.py
@@ -195,13 +195,14 @@ setup(
                 'pkg_resources',
                 'parso',
                 'pip',
+                "setuptools",
+                "packaging",
             ],
             includes=[
                 # 'csv',
                 # 'this'
             ] + stdLibIncludes,
             excludes=[
-                "packaging",
                 "numpy",
                 "scipy",
                 "matplotlib",


### PR DESCRIPTION
Attempt to fix #377  (edited was wrongly linked to 337)