### PR TITLE
Update drawBot.jpg URL

### DIFF
--- a/docs/content/quickReference.rst
+++ b/docs/content/quickReference.rst
@@ -44,7 +44,7 @@ Quick Reference
 
     newPage()
     # image: path, (x, y), alpha
-    image("https://d1sz9tkli0lfjq.cloudfront.net/items/1T3x1y372J371p0v1F2Z/drawBot.jpg", (10, 10), .5)
+    image("https://github.com/typemytype/drawbot/raw/master/docs/content/assets/drawBot.jpg", (10, 10), .5)
 
     newPage()
     print("pageCount:", pageCount())


### PR DESCRIPTION
The current cloudfront.net drawBot.jpg URL is broken, replaced it with the raw asset URL from this github repo.