### PR TITLE
Reload "path" font when the file changed on disk

### DIFF
--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -2639,13 +2639,20 @@ def getNSFontFromNameOrPath(fontNameOrPath, fontSize, fontNumber):
     return CoreText.CTFontCreateWithFontDescriptor(descriptors[fontNumber], fontSize, None)
 
 
+#
 # Cache for font descriptors that have been reloaded after a font file
-# changed on disk. We don't clear this cache, as the number of reloaded
+# changed on disk. Keys are absolute paths to font files, values are
+# (modificationTime, fontDescriptors) tuples. `fontDescriptors` is
+# None when the font was used but did not have to be reloaded, and a
+# list of font descriptors if the font has been reloaded before.
+#
+# We don't clear this cache, as the number of reloaded
 # fonts should generably be within reasonable limits, and re-reloading
 # upon every run (think Variable Sliders) is expensive.
 # NOTE: It's possible to turn this into a Least Recently Used cache with
 # a maximum size, using Python 3.7's insertion order preserving dict
 # behavior, but it may not be worth the effort.
+#
 _reloadedFontDescriptors = {}
 
 

--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -2646,9 +2646,10 @@ def getNSFontFromNameOrPath(fontNameOrPath, fontSize, fontNumber):
 # None when the font was used but did not have to be reloaded, and a
 # list of font descriptors if the font has been reloaded before.
 #
-# We don't clear this cache, as the number of reloaded
-# fonts should generably be within reasonable limits, and re-reloading
-# upon every run (think Variable Sliders) is expensive.
+# We don't clear this cache, as the number of reloaded fonts should
+# generably be within reasonable limits, and re-reloading upon every
+# run (think Variable Sliders) is expensive.
+#
 # NOTE: It's possible to turn this into a Least Recently Used cache with
 # a maximum size, using Python 3.7's insertion order preserving dict
 # behavior, but it may not be worth the effort.

--- a/drawBot/drawBotDrawingTools.py
+++ b/drawBot/drawBotDrawingTools.py
@@ -169,7 +169,6 @@ class DrawBotDrawingTool(object):
             saveImage("~/Desktop/anOval.pdf")
         """
         self._reset()
-        self.installedFonts()
 
     def endDrawing(self):
         """

--- a/tests/testMisc.py
+++ b/tests/testMisc.py
@@ -1,8 +1,11 @@
 import sys
 import os
+import pathlib
 import unittest
 import io
+import tempfile
 from collections import OrderedDict
+from fontTools.ttLib import TTFont
 import drawBot
 from drawBot.misc import DrawBotError, warnings
 from drawBot.scriptTools import ScriptRunner
@@ -301,6 +304,28 @@ class MiscTest(unittest.TestCase):
         self.assertEqual([i.bounds for i in bounds], [(10.0, 278.890625, 53.73046875, 11.77734375), (63.73046875, 274.671875, 114.755859375, 35.33203125), (178.486328125, 273.5, 91.611328125, 30.0), (10.0, 225.0, 206.640625, 40.0)])
         self.assertEqual([i.baselineOffset for i in bounds], [2.109375, 6.328125, 7.5, 10.0])
         self.assertEqual([str(i.formattedSubString) for i in bounds], ['hello hello ', 'foo foo ', 'bar bar ', 'world world '])
+
+    def test_reloadFont(self):
+        src = pathlib.Path(__file__).resolve().parent / "data" / "MutatorSans.ttf"
+        assert src.exists()
+        with tempfile.NamedTemporaryFile(suffix=".ttf") as ff:
+            ff.write(src.read_bytes())
+            firstModTime = os.stat(ff.name).st_mtime
+            drawBot.newDrawing()
+            path = drawBot.BezierPath()
+            path.text("E", font=ff.name, fontSize=1000)
+            self.assertEqual((60.0, 0.0, 340.0, 700.0), path.bounds())
+            ff.seek(0)
+            ttf = TTFont(ff)
+            ttf["glyf"]["E"].coordinates[0] = (400, 800)
+            ff.seek(0)
+            ttf.save(ff)
+            secondModTime = os.stat(ff.name).st_mtime
+            assert firstModTime != secondModTime, (firstModTime, secondModTime)
+            drawBot.newDrawing()  # to clear the memioze cache in baseContext
+            path = drawBot.BezierPath()
+            path.text("E", font=ff.name, fontSize=1000)
+            self.assertEqual((60.0, 0.0, 400.0, 800.0), path.bounds())
 
 
 def _roundInstanceLocations(instanceLocations):

--- a/tests/testMisc.py
+++ b/tests/testMisc.py
@@ -322,7 +322,7 @@ class MiscTest(unittest.TestCase):
             ttf.save(ff)
             secondModTime = os.stat(ff.name).st_mtime
             assert firstModTime != secondModTime, (firstModTime, secondModTime)
-            drawBot.newDrawing()  # to clear the memioze cache in baseContext
+            drawBot.newDrawing()  # to clear the memoize cache in baseContext
             path = drawBot.BezierPath()
             path.text("E", font=ff.name, fontSize=1000)
             self.assertEqual((60.0, 0.0, 400.0, 800.0), path.bounds())


### PR DESCRIPTION
This fixes #112.

I managed to do this efficiently without requiring an explicit `reloadFont()` function, byt looking at the modification time at the right moments.