### PR TITLE
Raise IndexError when ttc/dfont fontNumber is out of range

### DIFF
--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -2634,12 +2634,10 @@ def getNSFontFromNameOrPath(fontNameOrPath, fontSize, fontNumber):
     if not descriptors:
         return None
     if not 0 <= fontNumber < len(descriptors):
-        warnings.warn(
-            f"font: fontNumber out of range for '{fontPath}': "
-            f"{fontNumber} not in range 0..{len(descriptors) - 1}; "
-            f"falling back to 0"
+        raise IndexError(
+            f"fontNumber out of range for '{fontPath}': "
+            f"{fontNumber} not in range 0..{len(descriptors) - 1}"
         )
-        fontNumber = 0
     return CoreText.CTFontCreateWithFontDescriptor(descriptors[fontNumber], fontSize, None)
 
 

--- a/drawBot/drawBotDrawingTools.py
+++ b/drawBot/drawBotDrawingTools.py
@@ -1321,9 +1321,9 @@ class DrawBotDrawingTool(object):
 
             font("Times-Italic")
         """
+        font = getNSFontFromNameOrPath(fontNameOrPath, fontSize or 10, fontNumber)
         self._dummyContext.font(fontNameOrPath, fontSize, fontNumber)
         self._addInstruction("font", fontNameOrPath, fontSize, fontNumber)
-        font = getNSFontFromNameOrPath(fontNameOrPath, fontSize or 10, fontNumber)
         return getFontName(font)
 
     def fallbackFont(self, fontNameOrPath, fontNumber=0):

--- a/tests/testMisc.py
+++ b/tests/testMisc.py
@@ -331,6 +331,17 @@ class MiscTest(unittest.TestCase):
             path.text("E", font=ff.name, fontSize=1000)
             self.assertEqual((60.0, 0.0, 400.0, 800.0), path.bounds())
 
+    def test_ttc_IndexError(self):
+        src = pathlib.Path(__file__).resolve().parent / "data" / "MutatorSans.ttc"
+        self.assertEqual("MutatorMathTest-LightCondensed", drawBot.font(src, fontNumber=0))
+        self.assertEqual("MutatorMathTest-LightWide", drawBot.font(src, fontNumber=1))
+        self.assertEqual("MutatorMathTest-BoldCondensed", drawBot.font(src, fontNumber=2))
+        self.assertEqual("MutatorMathTest-BoldWide", drawBot.font(src, fontNumber=3))
+        with self.assertRaises(IndexError):
+            drawBot.font(src, fontNumber=4)
+        with self.assertRaises(IndexError):
+            drawBot.font(src, fontNumber=-1)
+
 
 def _roundInstanceLocations(instanceLocations):
     return {instanceName: {tag: round(value, 3) for tag, value in location.items()} for instanceName, location in instanceLocations.items()}


### PR DESCRIPTION
We know when the index is out of range, it seems better to raise an error than to warn, esp. since this will allow us to iterate and find out how many and which fonts are in the ttc/dfont.