### PR TITLE
Improve error messages for ill-specified fonts

### DIFF
--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -2620,6 +2620,13 @@ class BaseContext(object):
 
 @memoize
 def getNSFontFromNameOrPath(fontNameOrPath, fontSize, fontNumber):
+    font = _getNSFontFromNameOrPath(fontNameOrPath, fontSize, fontNumber)
+    if font is None:
+        warnings.warn(f"not font could be found for '{fontNameOrPath}'")
+    return font
+
+
+def _getNSFontFromNameOrPath(fontNameOrPath, fontSize, fontNumber):
     if fontSize is None:
         fontSize = 10
     if isinstance(fontNameOrPath, str):

--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -2620,6 +2620,11 @@ class BaseContext(object):
 
 @memoize
 def getNSFontFromNameOrPath(fontNameOrPath, fontSize, fontNumber):
+    if not isinstance(fontNameOrPath, (str, os.PathLike)):
+        tp = type(fontNameOrPath).__name__
+        raise TypeError(
+            f"'fontNameOrPath' should be str or path-like, '{tp}' found"
+        )
     font = _getNSFontFromNameOrPath(fontNameOrPath, fontSize, fontNumber)
     if font is None:
         warnings.warn(f"not font could be found for '{fontNameOrPath}'")


### PR DESCRIPTION
This should improve error messages for #429:
- warn if a font can't be located by name nor by path
- raise TypeError if `fontNameOrPath` argument is neither a string nor a path-like object