### PR TITLE
work around fonttools warning

### DIFF
--- a/tests/data/expected_fontAttributes.txt
+++ b/tests/data/expected_fontAttributes.txt
@@ -1,19 +1,19 @@
-Helvetica
-Helvetica
+Times
+Times-Roman
 True
 True
 False
 True
 True
 False
-Helvetica.ttc
+Times.ttc
 ['.null', 'nonmarkingreturn', 'space', 'exclam', 'quotedbl', 'numbersign']
-38.5009765625
--11.4990234375
-26.1474609375
-35.8642578125
+37.5
+-12.5
+22.6806640625
+33.0810546875
 0.0
-60.0
+61.0
 
 ../data/MutatorSans.ttf
 MutatorMathTest-LightCondensed

--- a/tests/drawBotScripts/fontAttributes.py
+++ b/tests/drawBotScripts/fontAttributes.py
@@ -3,7 +3,7 @@ import drawBot
 drawBot.size(50, 50)
 characters = "Aa今"
 glyphNames = ["A", "a", "zzz"]
-for fontName in ["Helvetica", "../data/MutatorSans.ttf"]:
+for fontName in ["Times", "../data/MutatorSans.ttf"]:
     print(fontName)
     print(drawBot.font(fontName))
     drawBot.fontSize(50)


### PR DESCRIPTION
I didn't manage to suppress the warning, so I switched to a font that doesn't emit the warning.