### PR TITLE
Improve all image object generators

### DIFF
--- a/drawBot/context/tools/imageObject.py
+++ b/drawBot/context/tools/imageObject.py
@@ -192,11 +192,20 @@ class ImageObject(object):
                 w, h = filterDict["size"]
                 dummy = AppKit.NSImage.alloc().initWithSize_((w, h))
                 generator = ciFilter.valueForKey_("outputImage")
+                extent = generator.extent()
+                scaleX = w / extent.size.width
+                scaleY = h / extent.size.height
                 dummy.lockFocus()
                 ctx = AppKit.NSGraphicsContext.currentContext()
                 ctx.setShouldAntialias_(False)
                 ctx.setImageInterpolation_(AppKit.NSImageInterpolationNone)
-                generator.drawAtPoint_fromRect_operation_fraction_((0, 0), ((0, 0), (w, h)), AppKit.NSCompositeCopy, 1)
+                fromRect = (0, 0), (w, h)
+                if filterDict.get("fitImage", False):
+                    transform = AppKit.NSAffineTransform.transform()
+                    transform.scaleXBy_yBy_(scaleX, scaleY)
+                    transform.concat()
+                    fromRect = extent
+                generator.drawAtPoint_fromRect_operation_fraction_((0, 0), fromRect, AppKit.NSCompositeCopy, 1)
                 dummy.unlockFocus()
                 rep = _makeBitmapImageRep(dummy)
                 self._cachedImage = AppKit.CIImage.alloc().initWithBitmapImageRep_(rep)
@@ -1269,6 +1278,7 @@ class ImageObject(object):
         filterDict = dict(name="CIAztecCodeGenerator", attributes=attr)
         filterDict["size"] = size
         filterDict["isGenerator"] = True
+        filterDict["fitImage"] = True
         self._addFilter(filterDict)
 
     def QRCodeGenerator(self, size, message=None, correctionLevel=None):
@@ -1287,6 +1297,7 @@ class ImageObject(object):
         filterDict = dict(name="CIQRCodeGenerator", attributes=attr)
         filterDict["size"] = size
         filterDict["isGenerator"] = True
+        filterDict["fitImage"] = True
         self._addFilter(filterDict)
 
     def code128BarcodeGenerator(self, size, message=None, quietSpace=None):
@@ -1303,6 +1314,7 @@ class ImageObject(object):
         filterDict = dict(name="CICode128BarcodeGenerator", attributes=attr)
         filterDict["size"] = size
         filterDict["isGenerator"] = True
+        filterDict["fitImage"] = True
         self._addFilter(filterDict)
 
     def checkerboardGenerator(self, size, center=None, color0=None, color1=None, width=None, sharpness=None):
@@ -1367,6 +1379,7 @@ class ImageObject(object):
         filterDict = dict(name="CILenticularHaloGenerator", attributes=attr)
         filterDict["size"] = size
         filterDict["isGenerator"] = True
+        filterDict["fitImage"] = True
         self._addFilter(filterDict)
 
     def PDF417BarcodeGenerator(self, size, message=None, minWidth=None, maxWidth=None, minHeight=None, maxHeight=None, dataColumns=None, rows=None, preferredAspectRatio=None, compactionMode=None, compactStyle=None, correctionLevel=None, alwaysSpecifyCompaction=None):
@@ -1403,6 +1416,7 @@ class ImageObject(object):
         filterDict = dict(name="CIPDF417BarcodeGenerator", attributes=attr)
         filterDict["size"] = size
         filterDict["isGenerator"] = True
+        filterDict["fitImage"] = True
         self._addFilter(filterDict)
 
     def randomGenerator(self, size):
@@ -1489,6 +1503,7 @@ class ImageObject(object):
         filterDict = dict(name="CISunbeamsGenerator", attributes=attr)
         filterDict["size"] = size
         filterDict["isGenerator"] = True
+        filterDict["fitImage"] = True
         self._addFilter(filterDict)
 
     def crop(self, rectangle=None):

--- a/drawBot/context/tools/imageObject.py
+++ b/drawBot/context/tools/imageObject.py
@@ -189,10 +189,11 @@ class ImageObject(object):
                 ciFilter.setValue_forKey_(value, key)
 
             if filterDict.get("isGenerator", False):
-                w, h = filterDict["size"]
-                dummy = AppKit.NSImage.alloc().initWithSize_((w, h))
                 generator = ciFilter.valueForKey_("outputImage")
                 extent = generator.extent()
+                w, h = filterDict.get("size", extent.size)
+                dummy = AppKit.NSImage.alloc().initWithSize_((w, h))
+
                 scaleX = w / extent.size.width
                 scaleY = h / extent.size.height
                 dummy.lockFocus()
@@ -1260,7 +1261,7 @@ class ImageObject(object):
         filterDict = dict(name="CIVortexDistortion", attributes=attr)
         self._addFilter(filterDict)
 
-    def aztecCodeGenerator(self, size, message=None, correctionLevel=None, layers=None, compactStyle=None):
+    def aztecCodeGenerator(self, size=None, message=None, correctionLevel=None, layers=None, compactStyle=None):
         """
         Generates an Aztec code (two-dimensional barcode) from input data.
 
@@ -1276,12 +1277,13 @@ class ImageObject(object):
         if compactStyle:
             attr["inputCompactStyle"] = compactStyle
         filterDict = dict(name="CIAztecCodeGenerator", attributes=attr)
-        filterDict["size"] = size
+        if size:
+            filterDict["size"] = size
         filterDict["isGenerator"] = True
         filterDict["fitImage"] = True
         self._addFilter(filterDict)
 
-    def QRCodeGenerator(self, size, message=None, correctionLevel=None):
+    def QRCodeGenerator(self, size=None, message=None, correctionLevel=None):
         """
         Generates a Quick Response code (two-dimensional barcode) from input data.
 
@@ -1295,12 +1297,13 @@ class ImageObject(object):
             assert correctionLevel in "LMQH", "'correctionLevel' must be either 'L', 'M', 'Q', 'H'"
             attr["inputCorrectionLevel"] = correctionLevel
         filterDict = dict(name="CIQRCodeGenerator", attributes=attr)
-        filterDict["size"] = size
+        if size:
+            filterDict["size"] = size
         filterDict["isGenerator"] = True
         filterDict["fitImage"] = True
         self._addFilter(filterDict)
 
-    def code128BarcodeGenerator(self, size, message=None, quietSpace=None):
+    def code128BarcodeGenerator(self, size=None, message=None, quietSpace=None):
         """
         Generates a Code 128 one-dimensional barcode from input data.
 
@@ -1312,7 +1315,8 @@ class ImageObject(object):
         if quietSpace:
             attr["inputQuietSpace"] = quietSpace
         filterDict = dict(name="CICode128BarcodeGenerator", attributes=attr)
-        filterDict["size"] = size
+        if size:
+            filterDict["size"] = size
         filterDict["isGenerator"] = True
         filterDict["fitImage"] = True
         self._addFilter(filterDict)
@@ -1353,7 +1357,7 @@ class ImageObject(object):
         filterDict["isGenerator"] = True
         self._addFilter(filterDict)
 
-    def lenticularHaloGenerator(self, size, center=None, color=None, haloRadius=None, haloWidth=None, haloOverlap=None, striationStrength=None, striationContrast=None, time=None):
+    def lenticularHaloGenerator(self, size=None, center=None, color=None, haloRadius=None, haloWidth=None, haloOverlap=None, striationStrength=None, striationContrast=None, time=None):
         """
         Simulates a lens flare.
 
@@ -1377,12 +1381,13 @@ class ImageObject(object):
         if time:
             attr["inputTime"] = time
         filterDict = dict(name="CILenticularHaloGenerator", attributes=attr)
-        filterDict["size"] = size
+        if size:
+            filterDict["size"] = size
         filterDict["isGenerator"] = True
         filterDict["fitImage"] = True
         self._addFilter(filterDict)
 
-    def PDF417BarcodeGenerator(self, size, message=None, minWidth=None, maxWidth=None, minHeight=None, maxHeight=None, dataColumns=None, rows=None, preferredAspectRatio=None, compactionMode=None, compactStyle=None, correctionLevel=None, alwaysSpecifyCompaction=None):
+    def PDF417BarcodeGenerator(self, size=None, message=None, minWidth=None, maxWidth=None, minHeight=None, maxHeight=None, dataColumns=None, rows=None, preferredAspectRatio=None, compactionMode=None, compactStyle=None, correctionLevel=None, alwaysSpecifyCompaction=None):
         """
         Generates a PDF417 code (two-dimensional barcode) from input data.
 
@@ -1414,7 +1419,8 @@ class ImageObject(object):
         if alwaysSpecifyCompaction:
             attr["inputAlwaysSpecifyCompaction"] = alwaysSpecifyCompaction
         filterDict = dict(name="CIPDF417BarcodeGenerator", attributes=attr)
-        filterDict["size"] = size
+        if size:
+            filterDict["size"] = size
         filterDict["isGenerator"] = True
         filterDict["fitImage"] = True
         self._addFilter(filterDict)
@@ -1479,7 +1485,7 @@ class ImageObject(object):
         filterDict["isGenerator"] = True
         self._addFilter(filterDict)
 
-    def sunbeamsGenerator(self, size, center=None, color=None, sunRadius=None, maxStriationRadius=None, striationStrength=None, striationContrast=None, time=None):
+    def sunbeamsGenerator(self, size=None, center=None, color=None, sunRadius=None, maxStriationRadius=None, striationStrength=None, striationContrast=None, time=None):
         """
         Generates a sun effect.
 
@@ -1501,7 +1507,8 @@ class ImageObject(object):
         if time:
             attr["inputTime"] = time
         filterDict = dict(name="CISunbeamsGenerator", attributes=attr)
-        filterDict["size"] = size
+        if size:
+            filterDict["size"] = size
         filterDict["isGenerator"] = True
         filterDict["fitImage"] = True
         self._addFilter(filterDict)


### PR DESCRIPTION
Scale the generated image to fit the requested size
If the generate has "endless" in size (fe random, checkBoard, constanstColor, ...) just draw it in the requested size.

```python
w, h = 150, 150
message = bytes('https://drawbot.com', 'latin-1')


newPage(w + 20, h + 20)
img = ImageObject()
img.aztecCodeGenerator((w, h), message)
image(img, (10, 10))

newPage(w + 20, h + 20)
img = ImageObject()
# size becomes optional
img.aztecCodeGenerator(message=message)
image(img, (10, 10))

newPage(w + 20, h + 20)
img = ImageObject()
img.QRCodeGenerator((w, h), message, 'H')
image(img, (10, 10))

newPage(w + 20, h + 20)
img = ImageObject()
img.code128BarcodeGenerator((w, h), message, 0)
image(img, (10, 10))

newPage(w + 20, h + 20)
img = ImageObject()
img.checkerboardGenerator((w, h), width=20)
image(img, (10, 10))


newPage()
img = ImageObject()
img.constantColorGenerator((w, h), (1, 1, 0, 1))
image(img, (10, 10))


newPage()
img = ImageObject()
img.lenticularHaloGenerator((w, h))
image(img, (10, 10))

newPage()
img = ImageObject()
img.PDF417BarcodeGenerator((w, h), message)
image(img, (10, 10))

newPage()
img = ImageObject()
img.randomGenerator((w, h))
image(img, (10, 10))

newPage()
img = ImageObject()
img.starShineGenerator((w, h), center=(w/2, h/2), color=(1, 0, 0, 1), radius=20)
image(img, (10, 10))

newPage()
img = ImageObject()
img.stripesGenerator((w, h), width=10)
image(img, (10, 10))

newPage()
img = ImageObject()
img.sunbeamsGenerator((w, h), center=(w/2, h/2))
image(img, (10, 10))
```

result of this PR:

![image](https://user-images.githubusercontent.com/1190358/163676186-09160c0c-e178-44e4-a1ec-281bf13e3966.png)
