### PR TITLE
Fix for #485: don't assume the axis name exists

### DIFF
--- a/drawBot/context/tools/variation.py
+++ b/drawBot/context/tools/variation.py
@@ -39,7 +39,7 @@ def getVariationAxesForFont(font):
         return axes
     for variationAxesDescription in variationAxesDescriptions:
         tag = convertIntToVariationTag(variationAxesDescription[CoreText.kCTFontVariationAxisIdentifierKey])
-        name = variationAxesDescription[CoreText.kCTFontVariationAxisNameKey]
+        name = variationAxesDescription.get(CoreText.kCTFontVariationAxisNameKey, tag)
         minValue = variationAxesDescription[CoreText.kCTFontVariationAxisMinimumValueKey]
         maxValue = variationAxesDescription[CoreText.kCTFontVariationAxisMaximumValueKey]
         defaultValue = variationAxesDescription[CoreText.kCTFontVariationAxisDefaultValueKey]


### PR DESCRIPTION
If an fvar axis uses a nameID that isn't in the name table, `CoreText.kCTFontVariationAxisNameKey` isn't in the description dict; fall back to the tag.

This fixes #485