### PR TITLE
Correct docstring

### DIFF
--- a/drawBot/drawBotDrawingTools.py
+++ b/drawBot/drawBotDrawingTools.py
@@ -1818,7 +1818,7 @@ class DrawBotDrawingTool(object):
 
     def textBoxCharacterBounds(self, txt, box, align=None):
         """
-        Returns a list of typesetted bounding boxes `((x, y, w, h), baseLineOffset, characters, formattedString)`.
+        Returns a list of typesetted bounding boxes `((x, y, w, h), baseLineOffset, formattedSubString)`.
 
         A `box` could be a `(x, y, w, h)` or a bezierPath object.
 

--- a/tests/data/expected_fontAttributes.txt
+++ b/tests/data/expected_fontAttributes.txt
@@ -41,6 +41,6 @@ MutatorSans.ttc 2
 MutatorMathTest-BoldWide
 MutatorSans.ttc 3
 
-Courier Courier.dfont 0
-Courier-Bold Courier.dfont 1
-Courier-Oblique Courier.dfont 2
+Courier Courier.ttc 0
+Courier-Bold Courier.ttc 1
+Courier-Oblique Courier.ttc 2


### PR DESCRIPTION
`textBoxCharacterBounds()` does not return `characters`

```
CharactersBounds(bounds=(0.0, 0.890625, 195.361328125, 11.77734375), baselineOffset=2.109375, formattedSubString=some text )
```