### PR TITLE
textProperties

### DIFF
--- a/docs/content/text/textProperties.rst
+++ b/docs/content/text/textProperties.rst
@@ -16,6 +16,7 @@ Text Properties
 .. autofunction:: drawBot.listNamedInstances
 .. autofunction:: drawBot.tabs
 .. autofunction:: drawBot.language
+.. autofunction:: drawBot.textProperties
 
 Font Properties
 ---------------

--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -1099,6 +1099,15 @@ class FormattedString(SVGContextPropertyMixin, ContextPropertyMixin):
                 self._setAttribute(key, value)
             self._setColorAttributes(attributes)
 
+    def textProperties(self):
+        """
+        Return a dict with all current stylistic text properties.
+        """
+        return {
+            attributeName: getattr(self, f"_{attributeName}", defaultValue)
+            for attributeName, defaultValue in self._formattedAttributes.items()
+        }
+
     def _setAttribute(self, attribute, value):
         method = getattr(self, attribute)
         if isinstance(value, (list, tuple)):
@@ -1113,7 +1122,7 @@ class FormattedString(SVGContextPropertyMixin, ContextPropertyMixin):
         for key in colorAttributeNames:
             value = attributes.get(key)
             if value is not None:
-                setattr(self, "_%s" % key, value)
+                setattr(self, f"_{key}", value)
 
         if self._fill is not None:
             try:
@@ -1195,14 +1204,14 @@ class FormattedString(SVGContextPropertyMixin, ContextPropertyMixin):
         elif not isinstance(txt, (str, FormattedString)):
             raise TypeError("expected 'str' or 'FormattedString', got '%s'" % type(txt).__name__)
         attributes = {}
+        # store all formattedString settings in a custom attributes key
+        attributes["drawBot.formattedString.properties"] = self.textProperties()
         attributes[AppKit.NSLigatureAttributeName] = 1  # https://github.com/typemytype/drawbot/issues/427
         if self._font:
             font = self._getNSFontWithFallback()
             coreTextFontFeatures = []
             nsFontFeatures = []  # fallback for macOS < 10.13
             if self._openTypeFeatures:
-                # store openTypeFeatures in a custom attributes key
-                attributes["drawbot.openTypeFeatures"] = dict(self._openTypeFeatures)
                 # get existing openTypeFeatures for the font
                 existingOpenTypeFeatures = openType.getFeatureTagsForFont(font)
                 # sort features by their on/off state
@@ -1389,7 +1398,10 @@ class FormattedString(SVGContextPropertyMixin, ContextPropertyMixin):
                 length = 0
 
             rng = location, length
-            attributes = {key: getattr(self, "_%s" % key) for key in self._formattedAttributes}
+            if textLength == 0:
+                attributes = self.textProperties()
+            else:
+                attributes, _ = self._attributedString.attribute_atIndex_effectiveRange_("drawBot.formattedString.properties", location + length - 1, None)
             new = self.__class__(**attributes)
             try:
                 new._attributedString = self._attributedString.attributedSubstringFromRange_(rng)

--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -1103,10 +1103,14 @@ class FormattedString(SVGContextPropertyMixin, ContextPropertyMixin):
         """
         Return a dict with all current stylistic text properties.
         """
-        return {
-            attributeName: getattr(self, f"_{attributeName}", defaultValue)
-            for attributeName, defaultValue in self._formattedAttributes.items()
-        }
+        properties = dict()
+        for attributeName, defaultValue in self._formattedAttributes.items():
+            value = getattr(self, f"_{attributeName}", defaultValue)
+            # create new object if the value is a dictionary
+            if isinstance(value, dict):
+                value = dict(value)
+            properties[attributeName] = value
+        return properties
 
     def _setAttribute(self, attribute, value):
         method = getattr(self, attribute)

--- a/drawBot/context/svgContext.py
+++ b/drawBot/context/svgContext.py
@@ -438,7 +438,7 @@ class SVGContext(BaseContext):
                 strokeColor = attributes.get(AppKit.NSStrokeColorAttributeName)
                 strokeWidth = attributes.get(AppKit.NSStrokeWidthAttributeName, self._state.strokeWidth)
                 baselineShift = attributes.get(AppKit.NSBaselineOffsetAttributeName, 0)
-                openTypeFeatures = attributes.get("drawbot.openTypeFeatures")
+                openTypeFeatures = attributes.get("drawBot.formattedString.properties", dict()).get("openTypeFeatures")
                 underline = attributes.get(AppKit.NSUnderlineStyleAttributeName)
                 url = attributes.get(AppKit.NSLinkAttributeName)
 

--- a/drawBot/drawBotDrawingTools.py
+++ b/drawBot/drawBotDrawingTools.py
@@ -1601,6 +1601,11 @@ class DrawBotDrawingTool(object):
 
     listNamedInstances.__doc__ = FormattedString.listNamedInstances.__doc__
 
+    def textProperties(self):
+        return self._dummyContext._state.text.textProperties()
+
+    textProperties.__doc__ = FormattedString.textProperties.__doc__
+
     # drawing text
 
     def text(self, txt, position, align=None):

--- a/tests/testMisc.py
+++ b/tests/testMisc.py
@@ -81,6 +81,29 @@ class MiscTest(unittest.TestCase):
         namedInstances = _roundInstanceLocations(namedInstances)
         self.assertEqual(namedInstances, expectedNamedInstances)
 
+    def test_textProperties(self):
+        drawBot.newDrawing()
+        fs = drawBot.FormattedString()
+        self.assertEqual(fs.textProperties(), fs._formattedAttributes)
+        fs.font("Skia")
+        self.assertEqual(fs.textProperties()["font"], "Skia")
+        fs.fill(1, 0, 0)
+        self.assertEqual(fs.textProperties()["fill"], (1, 0, 0))
+        fs.openTypeFeatures(liga=True)
+        self.assertEqual(fs.textProperties()["openTypeFeatures"], dict(liga=True))
+
+        fs += "foo"
+        fs.fill(0, 1, 0)
+        fs += "bar"
+        fs.fill(None)
+        fs += "world"
+        characterBounds = drawBot.textBoxCharacterBounds(fs, (0, 0, 1000, 1000))
+        fillColors = []
+        for characterBound in characterBounds:
+            fillColors.append(characterBound.formattedSubString.textProperties()["fill"])
+        self.assertEqual(fillColors, [(1, 0, 0), (0, 1, 0), None])
+
+
     def test_polygon_notEnoughPoints(self):
         drawBot.newDrawing()
         with self.assertRaises(TypeError):


### PR DESCRIPTION
textProperties returns a dict with all current properties of an formattedString. 

While building the nsAttributedString those properties are stored in the nsAttributedString with the key: `"drawBot.formattedString.properties"`. This allows to slice a formattedString and restore the attributes from the nsAttributedString.

The method is a public one as this can be used to check text properties after creating/building the formattedString.

fixing #518