### PR TITLE
Add support for saving CMYK images

### DIFF
--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -392,7 +392,6 @@ class BezierPath(BasePen, SVGContextPropertyMixin, ContextPropertyMixin):
         path, (x, y) = context._getPathForFrameSetter(box)
         attributedString = context.attributedString(txt, align)
 
-        print("hip", hyphenation)
         if hyphenation:
             attributedString = context.hyphenateAttributedString(attributedString, path)
 

--- a/drawBot/context/baseContext.py
+++ b/drawBot/context/baseContext.py
@@ -392,6 +392,10 @@ class BezierPath(BasePen, SVGContextPropertyMixin, ContextPropertyMixin):
         path, (x, y) = context._getPathForFrameSetter(box)
         attributedString = context.attributedString(txt, align)
 
+        print("hip", hyphenation)
+        if hyphenation:
+            attributedString = context.hyphenateAttributedString(attributedString, path)
+
         setter = CoreText.CTFramesetterCreateWithAttributedString(attributedString)
         frame = CoreText.CTFramesetterCreateFrame(setter, (0, 0), path, None)
         ctLines = CoreText.CTFrameGetLines(frame)

--- a/drawBot/context/imageContext.py
+++ b/drawBot/context/imageContext.py
@@ -31,6 +31,12 @@ def _tiffCompressionConverter(value):
         return t.get(value.lower(), AppKit.NSTIFFCompressionNone)
 
 
+def _colorSpaceConverter(value):
+    if value == "CMYK":
+        return AppKit.NSDeviceCMYKColorSpace
+    return AppKit.NSCalibratedRGBColorSpace
+
+
 _nsImageOptions = {
     # DrawBot Key                   NSImage property key                    converter or None          doc
     "imageColorSyncProfileData":    (AppKit.NSImageColorSyncProfileData,    _nsDataConverter,          "A bytes or NSData object containing the ColorSync profile data."),
@@ -70,6 +76,7 @@ class ImageContext(PDFContext):
         ("antiAliasing", "Indicate if a the image should be rendedered with anti-aliasing. Default is True."),
         ("fontSubpixelQuantization", "A Boolean value that specifies whether subpixel quantization of glyphs is allowed. Default is True."),
         ("multipage", "Output a numbered image for each page or frame in the document."),
+        ("colorSpace", "Set color space (RGB, CMYK). Default is RGB."),
     ]
 
     ensureEvenPixelDimensions = False
@@ -90,6 +97,10 @@ class ImageContext(PDFContext):
         imageResolution = options.get("imageResolution", 72.0)
         antiAliasing = options.get("antiAliasing", True)
         fontSubpixelQuantization = options.get("fontSubpixelQuantization", True)
+
+        colorSpace = options.get("colorSpace", "RGB")
+        colorSpaceName = _colorSpaceConverter(colorSpace)
+
         properties = {}
         for key, value in options.items():
             if key in _nsImageOptions:
@@ -105,13 +116,21 @@ class ImageContext(PDFContext):
                     pdfPage=page,
                     antiAliasing=antiAliasing,
                     fontSubpixelQuantization=fontSubpixelQuantization,
-                    imageResolution=imageResolution
+                    imageResolution=imageResolution,
+                    colorSpaceName=colorSpaceName,
                 )
+
+                if "imageColorSyncProfileData" in options:
+                    imageRep.setProperty_withValue_(AppKit.NSImageColorSyncProfileData, options["imageColorSyncProfileData"])  # doing this with representationUsingType_properties_ does not work
+
                 if self.ensureEvenPixelDimensions:
                     if imageRep.pixelsWide() % 2 or imageRep.pixelsHigh() % 2:
                         raise DrawBotError("Exporting to %s doesn't support odd pixel dimensions for width and height." % (", ".join(self.fileExtensions)))
+
                 imageData = imageRep.representationUsingType_properties_(self._saveImageFileTypes[ext], properties)
+
                 imagePath = fileName + pathAdd + fileExt
+
                 self._storeImageData(imageData, imagePath)
                 pathAdd = "_%s" % (index + 2)
                 del page, imageRep, imageData
@@ -133,13 +152,17 @@ def _makeBitmapImageRep(nsImage=None, pdfPage=None, imageResolution=72.0, antiAl
     elif nsImage is not None:
         width, height = nsImage.size()
 
+    hasAlpha = True
+    if colorSpaceName == AppKit.NSDeviceCMYKColorSpace:
+        hasAlpha = False  # Quartz doesn’t support alpha for CMYK bitmaps.
+
     rep = AppKit.NSBitmapImageRep.alloc().initWithBitmapDataPlanes_pixelsWide_pixelsHigh_bitsPerSample_samplesPerPixel_hasAlpha_isPlanar_colorSpaceName_bytesPerRow_bitsPerPixel_(
         None,                                    # planes
         int(width * scaleFactor),                # pixelsWide
         int(height * scaleFactor),               # pixelsHigh
         8,                                       # bitsPerSample
         4,                                       # samplesPerPixel
-        True,                                    # hasAlpha
+        hasAlpha,                                # hasAlpha
         False,                                   # isPlanar
         colorSpaceName,                          # colorSpaceName
         0,                                       # bytesPerRow


### PR DESCRIPTION
I needed to export TIFF images with CMYK. Even though I was setting `imageColorSyncProfileData` with macOS's Generic CMYK profile, the final output file did not have the colour profile set, and the encoded colours were in the RGB space.

I would happily invest more time and add tests if this PR looks valuable for the project!

This PR is related to #284 and #531.