### PR TITLE
Remove redundant use of distutils

### DIFF
--- a/drawBot/macOSVersion.py
+++ b/drawBot/macOSVersion.py
@@ -1,4 +1,3 @@
-from distutils.version import StrictVersion
 from packaging.version import Version
 import platform
 


### PR DESCRIPTION
distutils is still used by setupApp.py, and that still seems to work on Python 3.12, but the unused StrictVersion import causes the built app to fail. It doesn't appear to be used anywhere.