### PR TITLE
Allow manual trigger; only release when on tag; but do upload action artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "*"
+  workflow_dispatch: # allow manual trigger
 
 jobs:
   build:
@@ -69,6 +70,7 @@ jobs:
         path: ./dist/notarize_log.txt
 
     - name: Read CHANGELOG.md
+      if: startsWith(github.event.ref, 'refs/tags')
       id: changelog
       env:
         GITHUB_REF: ${{ github.ref }}
@@ -77,7 +79,14 @@ jobs:
         # echo "::set-output name=body::$(python app/extract_changes.py)"
         echo "body=$(python app/extract_changes.py)" >> $GITHUB_OUTPUT
 
+    - name: Storing App Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: DrawBot.dmg
+        path: ./dist/DrawBot.dmg
+
     - name: Create Release
+      if: startsWith(github.event.ref, 'refs/tags')
       id: create_release
       uses: actions/create-release@master
       env:
@@ -90,6 +99,7 @@ jobs:
         body: ${{ steps.changelog.outputs.body }}
 
     - name: Upload Release Asset
+      if: startsWith(github.event.ref, 'refs/tags')
       id: upload-release-asset
       uses: actions/upload-release-asset@v1.0.1
       env:


### PR DESCRIPTION
This should make app build testing a bit easier: manual trigger, no need for tag/release.