### PR TITLE
Make sure we specify every axis in the font to ensure we get the expected default value behavior

### DIFF
--- a/drawBot/context/tools/variation.py
+++ b/drawBot/context/tools/variation.py
@@ -92,14 +92,17 @@ def getNamedInstancesForFont(font):
 def getFontVariationAttributes(font, fontVariations):
     coreTextFontVariations = dict()
     axes = getVariationAxesForFont(font)
+
     for axisTag, axis in axes.items():
         value = min(
             max(fontVariations.get(axisTag, axis["defaultValue"]), axis["minValue"]),
             axis["maxValue"],
         )
         coreTextFontVariations[convertVariationTagToInt(axisTag)] = value
+
     for axisTag in sorted(set(fontVariations) - set(axes)):
         warnings.warn(
             "variation axis '%s' not available for '%s'" % (axisTag, font.fontName())
         )
+
     return coreTextFontVariations

--- a/drawBot/context/tools/variation.py
+++ b/drawBot/context/tools/variation.py
@@ -93,8 +93,13 @@ def getFontVariationAttributes(font, fontVariations):
     coreTextFontVariations = dict()
     axes = getVariationAxesForFont(font)
     for axisTag, axis in axes.items():
-        value = fontVariations.get(axisTag, axis["defaultValue"])
+        value = min(
+            max(fontVariations.get(axisTag, axis["defaultValue"]), axis["minValue"]),
+            axis["maxValue"],
+        )
         coreTextFontVariations[convertVariationTagToInt(axisTag)] = value
     for axisTag in sorted(set(fontVariations) - set(axes)):
-        warnings.warn("variation axis '%s' not available for '%s'" % (axisTag, font.fontName()))
+        warnings.warn(
+            "variation axis '%s' not available for '%s'" % (axisTag, font.fontName())
+        )
     return coreTextFontVariations

--- a/drawBot/context/tools/variation.py
+++ b/drawBot/context/tools/variation.py
@@ -101,8 +101,6 @@ def getFontVariationAttributes(font, fontVariations):
         coreTextFontVariations[convertVariationTagToInt(axisTag)] = value
 
     for axisTag in sorted(set(fontVariations) - set(axes)):
-        warnings.warn(
-            "variation axis '%s' not available for '%s'" % (axisTag, font.fontName())
-        )
+        warnings.warn("variation axis '%s' not available for '%s'" % (axisTag, font.fontName()))
 
     return coreTextFontVariations

--- a/drawBot/context/tools/variation.py
+++ b/drawBot/context/tools/variation.py
@@ -91,17 +91,10 @@ def getNamedInstancesForFont(font):
 
 def getFontVariationAttributes(font, fontVariations):
     coreTextFontVariations = dict()
-    if fontVariations:
-        existingAxes = getVariationAxesForFont(font)
-        for axis, value in fontVariations.items():
-            if axis in existingAxes:
-                existinsAxis = existingAxes[axis]
-                # clip variation value within the min max value
-                if value < existinsAxis["minValue"]:
-                    value = existinsAxis["minValue"]
-                if value > existinsAxis["maxValue"]:
-                    value = existinsAxis["maxValue"]
-                coreTextFontVariations[convertVariationTagToInt(axis)] = value
-            else:
-                warnings.warn("variation axis '%s' not available for '%s'" % (axis, font.fontName()))
+    axes = getVariationAxesForFont(font)
+    for axisTag, axis in axes.items():
+        value = fontVariations.get(axisTag, axis["defaultValue"])
+        coreTextFontVariations[convertVariationTagToInt(axisTag)] = value
+    for axisTag in sorted(set(fontVariations) - set(axes)):
+        warnings.warn("variation axis '%s' not available for '%s'" % (axisTag, font.fontName()))
     return coreTextFontVariations


### PR DESCRIPTION
Somehow CoreText has different ideas what default to use if we don't specify an axis value. This PR reverses the logic of `getFontVariationAttributes()` and always sets all axis values.

This fixes #581.