### PR TITLE
adding align while calculating text bounds

### DIFF
--- a/drawBot/drawBotDrawingTools.py
+++ b/drawBot/drawBotDrawingTools.py
@@ -2030,7 +2030,7 @@ class DrawBotDrawingTool:
 
         bounds = list()
         path, (x, y) = self._dummyContext._getPathForFrameSetter(box)
-        attrString = self._dummyContext.attributedString(txt)
+        attrString = self._dummyContext.attributedString(txt, align=align)
         setter = newFramesetterWithAttributedString(attrString)
         box = CoreText.CTFramesetterCreateFrame(setter, (0, 0), path, None)
         ctLines = CoreText.CTFrameGetLines(box)


### PR DESCRIPTION
`align` is an unused argument to calculate the text bounds but required if a plain string is provided instead of a FormatteddString